### PR TITLE
Organization/Practitioner/Consent/Styling Notifications

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -89,3 +89,41 @@
     }
   }
 }
+
+.overflow-x-auto {
+  overflow-x: auto;
+}
+
+.text-xs-custom {
+  font-size: 0.75rem;
+}
+
+.text-gray-700-custom {
+  color: #4B5563;
+}
+
+.bg-gray-50-custom {
+  background-color: #F9FAFB;
+}
+
+.floating-label {
+  position: relative;
+}
+
+.floating-input:focus,
+.floating-input:not(:placeholder-shown) {
+  font-size: 0.75rem;
+  top: -0.5rem;
+}
+
+@media (min-width: 576px) {
+  .rounded-lg-custom {
+      border-radius: 3rem;
+  }
+}
+
+@media (min-width: 600px) {
+  .rounded-lg-custom {
+      border-radius: 1rem;
+  }
+}

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -5,7 +5,7 @@ class OrganizationsController < ApplicationController
     org = FHIR::Organization.new(
       active: true,
       name: params[:name],
-      telecom: org_telecom,
+      contact: org_contact,
       address: org_address,
     )
     org.create
@@ -13,25 +13,29 @@ class OrganizationsController < ApplicationController
     Rails.cache.delete("organizations")
   rescue => e
     flash[:error] = "Unable to create organization"
-
+  ensure
     redirect_to dashboard_path
   end
 
   private
 
-  def org_telecom
+  def org_contact
     [
       {
-        system: "phone",
-        value: params[:phone],
-      },
-      {
-        system: "email",
-        value: params[:email],
-      },
-      {
-        system: "url",
-        value: params[:url],
+        telecom: [
+          {
+            system: "phone",
+            value: params[:phone],
+          },
+          {
+            system: "email",
+            value: params[:email],
+          },
+          {
+            system: "url",
+            value: params[:url],
+          },
+        ],
       },
     ]
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,49 @@
+class OrganizationsController < ApplicationController
+  before_action :require_client
+
+  def create
+    org = FHIR::Organization.new(
+      active: true,
+      name: params[:name],
+      telecom: org_telecom,
+      address: org_address,
+    )
+    org.create
+    flash[:success] = "successfully created organization #{org.name}"
+    Rails.cache.delete("organizations")
+  rescue => e
+    flash[:error] = "Unable to create organization"
+
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def org_telecom
+    [
+      {
+        system: "phone",
+        value: params[:phone],
+      },
+      {
+        system: "email",
+        value: params[:email],
+      },
+      {
+        system: "url",
+        value: params[:url],
+      },
+    ]
+  end
+
+  def org_address
+    [
+      {
+        line: [params[:street]],
+        city: params[:city],
+        state: params[:state],
+        postalCode: params[:postal_code],
+      },
+    ]
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,6 @@ class SessionsController < ApplicationController
           server.name = server_name
         end
         save_server_base_url(fhir_server.base_url)
-        save_cp_url(params[:cp_url] || SessionHelper::DEFAULT_CP_URL)
         save_practitioner_id(TEST_PRACTITIONER_ID)
 
         flash[:success] = "Successfully connected to #{fhir_server.name}"
@@ -33,7 +32,6 @@ class SessionsController < ApplicationController
         flash[:error] = "Failed to connect to the provided server, verify the URL provided is correct."
         redirect_to home_path
       end
-
     rescue StandardError => e
       puts "Error happened:#{e.class} => #{e.message}"
       flash[:error] = "Failed to connect to the provided server, verify the URL provided is correct. Error: #{e.message}"
@@ -48,5 +46,4 @@ class SessionsController < ApplicationController
     flash[:success] = "Successfully disconnected from the FHIR server"
     redirect_to root_path
   end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -58,6 +58,7 @@ class SessionsController < ApplicationController
   # Post /set_current_practitioner
   def set_current_practitioner
     save_practitioner_id(params[:provider_id])
+    flash[:success] = "successfully signed in!"
     redirect_to dashboard_path
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  before_action :require_client, except: %i[index create]
   # Get /home
   def index
     if client_connected?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -129,8 +129,8 @@ class TasksController < ApplicationController
 
   def task_owner
     {
-      "reference": "#{get_cp_url}/Organization/#{params[:performer_id]}",
-      "display": performer_options.find { |arr| arr[1] == params[:performer_id] }&.first,
+      "reference": "Organization/#{params[:performer_id]}",
+      "display": organizations.find { |org| org.id == params[:performer_id] }&.name,
     }
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -120,10 +120,9 @@ class TasksController < ApplicationController
   end
 
   def task_requester
-    # TODO: Get the practioner role from the server and save it in the session when querying the practioner
     {
-      "reference": "PractitionerRole/SDOHCC-PractitionerRoleDrJanWaterExample",
-      "display": "Dr Jan Water Family Medicine Physician",
+      "reference": "PractitionerRole/#{fetch_and_cache_practitionerRoleId}",
+      "display": get_current_practitioner&.name,
     }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,6 @@ module ApplicationHelper
   include TasksHelper
   include ServiceRequestsHelper
 
-  TEST_PATIENT_ID = "smart-1288992"
   TEST_PRACTITIONER_ID = "SDOHCC-PractitionerDrJanWaterExample"
 
   def organizations
@@ -21,6 +20,19 @@ module ApplicationHelper
       if response.is_a?(FHIR::Bundle)
         entries = response.entry.map(&:resource)
         entries.map { |entry| Organization.new(entry) }
+      end
+    end
+  end
+
+  def consents
+    Rails.cache.fetch("consents_#{patient_id}", expires_in: 1.day) do
+      response = FHIR::Consent.search(patient: patient_id)
+
+      if response.is_a?(FHIR::Bundle)
+        entries = response.entry.map(&:resource)
+        entries.map { |entry| Consent.new(entry) }
+      else
+        Rails.logger.error "Error fetching consents"
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,8 +13,19 @@ module ApplicationHelper
 
   TEST_PATIENT_ID = "smart-1288992"
   TEST_PRACTITIONER_ID = "SDOHCC-PractitionerDrJanWaterExample"
-  #### Flash helpers ####
 
+  def organizations
+    Rails.cache.fetch("organizations", expires_in: 1.day) do
+      response = FHIR::Organization.search(_sort: "-_lastUpdated")
+
+      if response.is_a?(FHIR::Bundle)
+        entries = response.entry.map(&:resource)
+        entries.map { |entry| Organization.new(entry) }
+      end
+    end
+  end
+
+  #### Flash helpers ####
   def bootstrap_class_for(flash_type)
     case flash_type.to_sym
     when :success

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,8 +11,6 @@ module ApplicationHelper
   include TasksHelper
   include ServiceRequestsHelper
 
-  TEST_PRACTITIONER_ID = "SDOHCC-PractitionerDrJanWaterExample"
-
   def organizations
     Rails.cache.fetch("organizations", expires_in: 1.day) do
       response = FHIR::Organization.search(_sort: "-_lastUpdated")

--- a/app/helpers/practitioner_helper.rb
+++ b/app/helpers/practitioner_helper.rb
@@ -2,7 +2,7 @@ module PractitionerHelper
   include SessionHelper
 
   def save_current_practitioner(practitioner)
-    Rails.cache.write('practitioner', practitioner, expires_in: 1.day)
+    Rails.cache.write("practitioner", practitioner, expires_in: 1.day)
   end
 
   def save_practitioner_id(practitioner_id)
@@ -10,7 +10,7 @@ module PractitionerHelper
   end
 
   def get_current_practitioner
-    @current_practitioner = Rails.cache.read('practitioner')
+    @current_practitioner = Rails.cache.read("practitioner")
   end
 
   def practitioner_id
@@ -35,8 +35,32 @@ module PractitionerHelper
       end
     rescue Errno::ECONNREFUSED => e
       [false, "Connection refused. Please check FHIR server's URL #{get_server_base_url} is up and try again. #{e.message}"]
-    # rescue Rack::Timeout::RequestTimeoutException => e
-    #   [false, "Request timeout. Please try again later. #{e.message}"]
+      # rescue Rack::Timeout::RequestTimeoutException => e
+      #   [false, "Request timeout. Please try again later. #{e.message}"]
+    end
+  end
+
+  def fetch_and_cache_practitioners
+    Rails.cache.fetch("practitioners_#{session[:requester_server_base_url]}", expires_in: 1.day) do
+      response = FHIR::Practitioner.search
+
+      if response.is_a?(FHIR::Bundle)
+        entries = response.entry.map(&:resource)
+        entries.map { |entry| Practitioner.new(entry) }
+      else
+        raise "Error fetching Practitioners from FHIR server. You need to choose a test provider to continue. Status code: #{response.response[:code]}"
+      end
+    end
+  end
+
+  def fetch_and_cache_practitionerRoleId
+    Rails.cache.fetch("practitionerRoleId_#{session[:requester_server_base_url]}", expires_in: 1.day) do
+      response = FHIR::PractitionerRole.search(practitioner: practitioner_id)
+
+      if response.is_a?(FHIR::Bundle)
+        entries = response.entry.map(&:resource)
+        entries.first&.id
+      end
     end
   end
 end

--- a/app/helpers/session_helper.rb
+++ b/app/helpers/session_helper.rb
@@ -1,6 +1,4 @@
 module SessionHelper
-  DEFAULT_CP_URL = "http://localhost:8082/fhir".freeze
-
   def save_client(client)
     @fhir_client = Rails.cache.fetch("client", expires_in: 1.day) do
       client
@@ -20,16 +18,8 @@ module SessionHelper
     session[:fhir_server_base_url] = base_url
   end
 
-  def save_cp_url(cp_url)
-    session[:cp_url]
-  end
-
   def get_server_base_url
     session[:fhir_server_base_url]
-  end
-
-  def get_cp_url
-    session[:cp_url] || DEFAULT_CP_URL
   end
 
   def save_patients(patient_list)

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -13,8 +13,8 @@ module TasksHelper
         subject: patient_id,
         _profile: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement",
         requester: "PractitionerRole/SDOHCC-PractitionerRoleDrJanWaterExample",
-        _sort: "-_lastUpdated"
-      }
+        _sort: "-_lastUpdated",
+      },
     }
 
     begin
@@ -25,7 +25,7 @@ module TasksHelper
           Task.new(entry.resource)
         end
 
-        grp = {"active" => [], "completed" => []}
+        grp = { "active" => [], "completed" => [] }
         tasks.each do |task|
           grp["active"] << task if (task.status != "completed" && task.status != "cancelled" && task.status != "rejected")
           grp["completed"] << task if task.status == "completed"
@@ -40,14 +40,13 @@ module TasksHelper
     rescue StandardError => e
       [false, "Something went wrong. #{e.message}"]
     end
-
   end
 
   def category_options
     [
       ["Food Insecurity", "food-insecurity"],
       ["Housing Instability", "housing-instability"],
-      ["Transportation Insecurity", "transportation-insecurity"]
+      ["Transportation Insecurity", "transportation-insecurity"],
     ]
   end
 
@@ -62,11 +61,11 @@ module TasksHelper
         ["Patient referral to dietitian", "103699006"],
         ["Provision of food", "710925007"],
         ["Referral to community meals service", "713109004"],
-        ["Referral to social worker", "308440001"]
+        ["Referral to social worker", "308440001"],
       ],
       "housing-instability" => [
         ["Housing assessment", "225340009"],
-        ["Referral to housing service", "710911006"]
+        ["Referral to housing service", "710911006"],
       ],
       "transportation-insecurity" => [
         ["Education about benefits enrollment assistance program (procedure)", "464301000124106"],
@@ -84,11 +83,10 @@ module TasksHelper
         ["Referral to social worker (procedure)", "308440001"],
         ["Referral to case manager (procedure)", "464001000124109"],
         ["Transportation request (procedure)", "428632005"],
-        ["Transportation case management (procedure)", "410365006"]
-      ]
+        ["Transportation case management (procedure)", "410365006"],
+      ],
     }
   end
-
 
   def condition_options
     map = []
@@ -107,19 +105,4 @@ module TasksHelper
     end
     map
   end
-
-  # TODO: This is a placeholder for now.  We need to figure out how to query the available CP orgs from the server
-  def performer_options
-    [["ABC Coordination Platform","SDOHCC-OrganizationCoordinationPlatformExample"]]
-  end
-
-  def consent_options
-    map = []
-    consents = Rails.cache.read("consents_#{patient_id}") || []
-    consents.each do |consent|
-      map << [consent.code, consent.id]
-    end
-    map
-  end
-
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -7,12 +7,11 @@ module TasksHelper
 
   def fetch_tasks
     client = get_client
-    # TODO: requester is hard coded. Need to get the practitioner role id from the session
     search_params = {
       parameters: {
         subject: patient_id,
         _profile: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement",
-        requester: "PractitionerRole/SDOHCC-PractitionerRoleDrJanWaterExample",
+        requester: "PractitionerRole/#{fetch_and_cache_practitionerRoleId}",
         _sort: "-_lastUpdated",
       },
     }

--- a/app/javascript/controllers/polltasks_controller.js
+++ b/app/javascript/controllers/polltasks_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     const pollUrl = this.element.dataset.pollUrl;
     if (pollUrl) {
       this.pollTasks(pollUrl);
-      // this.pollingInterval = setInterval(() => this.pollTasks(pollUrl), 10000);
+      this.pollingInterval = setInterval(() => this.pollTasks(pollUrl), 2000);
     }
   }
 
@@ -32,14 +32,12 @@ export default class extends Controller {
           }
 
           if (response.flash) {
-            this.flashContainerTarget.innerHTML = `<div class="alert alert-notice alert-dismissible fade show" role="alert">${response.flash} <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+            this.flashContainerTarget.innerHTML = `<div class="alert alert-info alert-dismissible fade show" data-controller="toasts" role="alert">${response.flash} <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
           }
         }
-        setTimeout(() => this.pollTasks(pollUrl), 10000);
       })
       .catch((error) => {
         console.error(error);
-        setTimeout(() => this.pollTasks(pollUrl), 10000);
       });;
   }
 }

--- a/app/javascript/controllers/toasts_controller.js
+++ b/app/javascript/controllers/toasts_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toasts"
+export default class extends Controller {
+  connect() {
+    this.show();
+  }
+
+  show() {
+    this.element.classList.add("show");
+
+    setTimeout(() => {
+      this.hide();
+    }, 5000);
+  }
+
+  hide() {
+    this.element.classList.remove("show");
+    setTimeout(() => {
+      this.element.remove();
+    }, 500);
+  }
+}

--- a/app/models/concerns/model_helper.rb
+++ b/app/models/concerns/model_helper.rb
@@ -4,43 +4,50 @@ module ModelHelper
 
   def format_phone(fhir_telecom_arr)
     phone_numbers = fhir_telecom_arr.select do |telecom|
-      telecom.system == 'phone'
+      telecom.system == "phone"
     end.map { |phone| phone.value }
 
-    phone_numbers.join(', ')
+    phone_numbers.join(", ")
   end
 
   def format_email(fhir_telecom_arr)
     email_addresses = fhir_telecom_arr.select do |telecom|
-      telecom.system == 'email'
+      telecom.system == "email"
     end.map { |email| email.value }
 
-    email_addresses.join(', ')
+    email_addresses.join(", ")
   end
 
+  def format_url(fhir_telecom_arr)
+    urls = fhir_telecom_arr.select do |telecom|
+      telecom.system == "url"
+    end.map { |url| url.value }
+
+    urls.join(", ")
+  end
 
   def format_name(fhir_name_array)
     latest_name = latest_start_date_object(fhir_name_array)
     return "No name provided" if latest_name.nil?
 
-    given_names = latest_name.given.join(' ') if latest_name.given
+    given_names = latest_name.given.join(" ") if latest_name.given
     family_name = latest_name.family
-    suffix = latest_name.suffix.join(' ') if latest_name.suffix
+    suffix = latest_name.suffix.join(" ") if latest_name.suffix
 
-    [family_name, given_names, suffix].compact.join(' ')
+    [family_name, given_names, suffix].compact.join(" ")
   end
 
   def format_address(fhir_address_arr)
     latest_address = latest_start_date_object(fhir_address_arr)
     return "No address provided" if latest_address.nil?
 
-    line = latest_address.line.join(', ') if latest_address.line
+    line = latest_address.line.join(", ") if latest_address.line
     city = latest_address.city
     state = latest_address.state
     postal_code = latest_address.postalCode
     country = latest_address.country
 
-    [line, city, state, postal_code, country].compact.join(', ')
+    [line, city, state, postal_code, country].compact.join(", ")
   end
 
   def latest_start_date_object(array)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,14 @@
+# Organization Model
+class Organization < Resource
+  attr_reader :id, :fhir_resource, :name, :address, :phone, :email, :url
+
+  def initialize(fhir_organization)
+    @id = fhir_organization.id
+    @fhir_resource = fhir_organization
+    @name = fhir_organization.name
+    @address = format_address(fhir_organization.address)
+    @phone = format_phone(fhir_organization.telecom)
+    @email = format_email(fhir_organization.telecom)
+    @url = format_url(fhir_organization.telecom)
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,8 +7,9 @@ class Organization < Resource
     @fhir_resource = fhir_organization
     @name = fhir_organization.name
     @address = format_address(fhir_organization.address)
-    @phone = format_phone(fhir_organization.telecom)
-    @email = format_email(fhir_organization.telecom)
-    @url = format_url(fhir_organization.telecom)
+    telecom = fhir_organization.contact.first&.telecom || fhir_organization.telecom
+    @phone = format_phone(telecom)
+    @email = format_email(telecom)
+    @url = format_url(telecom)
   end
 end

--- a/app/views/action_steps/_action_steps.html.erb
+++ b/app/views/action_steps/_action_steps.html.erb
@@ -19,5 +19,5 @@
       <%= render "action_steps/form_modal" %>
     <% end %>
   <% end %>
-  <div id="flash-container" data-target="polltasks.flashContainer"></div>
+  <div id="flash-container" data-polltasks-target="flashContainer" class="position-fixed top-0 end-0 w-25" style="z-index: 1060;"></div>
 </div>

--- a/app/views/action_steps/_form_modal.html.erb
+++ b/app/views/action_steps/_form_modal.html.erb
@@ -32,21 +32,21 @@
             <%= f.date_field :occurrence, class: "form-control", data: { taskform_target: "occurrenceDate" } %>
           </div>
           <div class="mb-3">
-            <%= f.label :condition_ids, "Problem(s)", class: "form-label" %>
+            <%= f.label :condition_ids, "Problem", class: "form-label" %>
             <%= f.select :condition_ids, condition_options,  { prompt: 'Select Problem' }, { class: "form-select form-select-sm", data: { taskform_target: "condition" }} %>
           </div>
           <div class="mb-3">
-            <%= f.label :goal_ids, "Goal(s)", class: "form-label" %>
+            <%= f.label :goal_ids, "Goal", class: "form-label" %>
             <%= f.select :goal_ids, goal_options,  { prompt: 'Select Goal' }, { class: "form-select", data: { taskform_target: "goal" } } %>
           </div>
                     <hr>
           <div class="mb-3">
-            <%= f.label :performer_id, "Performer(s)", class: "form-label" %>
-            <%= f.select :performer_id, performer_options,  { prompt: 'Select Performer' }, { class: "form-select", data: { taskform_target: "performer" } } %>
+            <%= f.label :performer_id, "Performer", class: "form-label" %>
+            <%= f.collection_select :performer_id, organizations, :id, :name, { prompt: 'Select Performer' }, { class: "form-select", data: { taskform_target: "performer" } } %>
           </div>
           <div class="mb-3">
             <%= f.label :consent, "Consent", class: "form-label" %>
-            <%= f.select :consent, consent_options,  { prompt: 'Select Consent' }, { class: "form-select", data: { taskform_target: "consent" } } %>
+            <%= f.collection_select :consent, consents, :id, :code, { prompt: 'Select Consent' }, { class: "form-select", data: { taskform_target: "consent" } } %>
           </div>
       </div>
       <div class="modal-footer">

--- a/app/views/dashboard/_add_organization_modal.html.erb
+++ b/app/views/dashboard/_add_organization_modal.html.erb
@@ -1,0 +1,48 @@
+<div class="modal fade" id="add-organization-modal" tabindex="-1" role="dialog" aria-labelledby="newOrganizationDialogTitle" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="newOrganizationDialogTitle">Add New Organization</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= form_with url: organizations_path, method: :post, id: "organization-form", class: "form" do |f| %>
+          <div class="floating-label mb-3">
+            <%= f.text_field :name, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Name", required: true %>
+          </div>
+          <div class="row row-cols-1 row-cols-md-2 g-0 g-md-3">
+            <div class="floating-label mb-3">
+              <%= f.text_field :street, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Street Address", required: true %>
+            </div>
+            <div class="floating-label mb-3">
+              <%= f.text_field :city, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "City", required: true %>
+            </div>
+          </div>
+          <div class="row row-cols-1 row-cols-md-2 g-0 g-md-3">
+            <div class="floating-label mb-3">
+              <%= f.text_field :state, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "State: e.g. NY", required: true %>
+            </div>
+            <div class="floating-label mb-3">
+              <%= f.text_field :postal_code, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Postal Code: e.g. 20584", required: true %>
+            </div>
+          </div>
+          <div class="row row-cols-1 row-cols-md-2 g-0 g-md-3">
+            <div class="floating-label mb-3">
+              <%= f.telephone_field :phone, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Phone number: e.g. 555-555-5555" %>
+            </div>
+            <div class="floating-label mb-3">
+              <%= f.email_field :email, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Email: e.g. example@organization.com" %>
+            </div>
+            <div class="floating-label mb-3">
+              <%= f.url_field :url, class: "form-control floating-input border-0 border-bottom border-gray-300 bg-transparent peer", placeholder: "Server Base URL: e.g. https://fhirserver.com/fhir", required: true %>
+            </div>
+          </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <%= f.submit "Create Organization", class: "btn btn-primary" %>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/dashboard/_referral_organizations.html.erb
+++ b/app/views/dashboard/_referral_organizations.html.erb
@@ -1,3 +1,51 @@
+<!-- dashboard/_referral_organizations.html.erb -->
 <div class="tab-pane fade <%= 'show active' if active %>" id="<%= id %>" role="tabpanel" aria-labelledby="<%= id %>-tab">
-  This is the Referral Organizations tab where all referral org will be listed: name, contact, address , fhir_resource(json in popover)
+  <div class="position-relative shadow overflow-x-auto rounded-lg-custom mx-3 my-4">
+    <div class="d-flex align-items-center justify-content-between pb-4 mt-4 mx-4">
+      <h6 class="text-left fw-semibold text-secondary">Organizations</h6>
+      <button class="action-button btn btn-sm" data-bs-toggle="modal" data-bs-target="#add-organization-modal">
+        <span class="icon"><i class="bi bi-plus-lg text-primary"></i></span>
+        <span class="label">Add Organization</span>
+      </button>
+    </div>
+    <% if organizations.nil? %>
+      <p>Unable to fetch organizations.</p>
+    <% elsif organizations.empty? %>
+      <p>No organization found.</p>
+    <% else %>
+      <table class="table table-sm text-center text-xs-custom fw-semibold">
+        <thead class="text-xs-custom text-gray-700-custom text-uppercase bg-gray-50-custom">
+          <tr>
+            <th>Name</th>
+            <th>Address</th>
+            <th>Phone</th>
+            <th>Email</th>
+            <th>URL</th>
+            <th>FHIR Resource</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% organizations.each do |organization| %>
+            <tr>
+              <td><%= organization.name %></td>
+              <td><%= organization.address %></td>
+              <td><%= organization.phone %></td>
+              <td><%= organization.email %></td>
+              <td><%= organization.url %></td>
+              <td>
+                <%= link_to 'FHIR Resource', '#', data: { bs_toggle: 'modal', bs_target: "#fhir-resource-modal-#{organization.id}" } %>
+                <% content_for :modals do %>
+                  <%= render 'shared/fhir_resource_modal', resource: organization %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <% content_for :modals do %>
+        <%= render "dashboard/add_organization_modal" %>
+      <% end %>
+    <% end %>
+  </div>
+
 </div>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -16,11 +16,6 @@
             <%= form_tag connect_path, method: :post, class: "form-inline justify-content-center" do %>
               <%= hidden_field_tag :fhir_server_name, '', id: 'fhir_server_name' %>
               <%= select_tag :fhir_server_base_url, options_from_collection_for_select(@fhir_servers, "base_url", "name"), prompt: "Select a server", class: "form-control mb-2 mr-sm-2", id: 'fhir_server_base_url' %>
-              <div class="form-group">
-                <%= label_tag :cp_url, "CP Server base URL to use" %>
-                <%= text_field_tag :cp_url, '', class: "form-control" %>
-                <small class="form-text text-danger text-muted">Provide the CP base URL to connect for demo. The default CP server will be used for interactions otherwise.</small>
-              </div>
               <%= submit_tag "Connect", class: "btn btn-primary mb-2" %>
             <% end %>
 
@@ -39,11 +34,6 @@
               <div class="form-group">
                 <%= label_tag :fhir_server_base_url, "Server Base URL" %>
                 <%= text_field_tag :fhir_server_base_url, '', class: "form-control" %>
-              </div>
-              <div class="form-group">
-                <%= label_tag :cp_url, "CP Server base URL to use" %>
-                <%= text_field_tag :cp_url, '', class: "form-control" %>
-                <small class="form-text text-danger text-muted">Provide the CP base URL to connect for demo. The default CP server will be used for interactions otherwise.</small>
               </div>
               <%= submit_tag "Connect", class: "btn btn-primary mt-3" %>
             <% end %>

--- a/app/views/sessions/select_test_practitioner.html.erb
+++ b/app/views/sessions/select_test_practitioner.html.erb
@@ -1,0 +1,32 @@
+<div class="min-vh-100 bg-light d-flex align-items-center justify-content-center">
+  <div class="container px-4 mx-auto">
+    <div class="bg-white shadow-lg rounded-lg p-5 d-flex flex-column flex-md-row">
+      <div class="flex-grow-1 mb-4 md:mb-0">
+        <div class="mb-4 text-center">
+          <%= image_tag "logo.svg", alt: "Logo", class: "w-50" %>
+        </div>
+        <h1 class="h4 font-bold text-center mb-3">Referral Source Client App</h1>
+        <p class="text-muted text-center">
+          You have successfully connected to the FHIR server <%= get_server_base_url %>. Please select a test provider
+          to see patients' data.
+        </p>
+      </div>
+      <div class="flex-grow-1 md:ms-4">
+        <%= form_with(url: set_current_practitioner_path, method: :post, local: true, class: "space-y-4") do |form| %>
+          <h2 class="h5 font-bold mb-2">Select a test provider to continue</h2>
+          <div class="my-3">
+            <% @practitioners.each do |practitioner| %>
+              <div class="form-check mb-2">
+                <%= form.radio_button :provider_id, practitioner.id, class: 'form-check-input', required: true %>
+                <i class="bi bi-person-badge ms-2 text-danger"></i>
+                <%= form.label "provider_id_#{practitioner.id}", practitioner.name, class: 'form-check-label' %>
+              </div>
+            <% end %>
+          </div>
+          <%= form.submit "Connect", class: "btn btn-primary w-100 font-bold py-2 px-4 rounded-pill mb-2", id: 'submit-button' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -1,30 +1,12 @@
 <!-- app/views/shared/_flash_messages.html.erb -->
-<div id="flash-container">
-  <% flash.each do |type, message| %>
-    <div class="alert alert-<%= bootstrap_class_for(type) %> alert-dismissible fade show" role="alert">
-      <%= message %>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-  <% end %>
-</div>
-
-<!--<% if flash.count != 0 %>
-  <div id="flash-container">
-    <% flash.each do |type, message| %>
-      <% next unless %w[alert notice].include?(type) %>
-
-      <div class="toast toast--<%= type %>" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="toast-body">
-          <span class="mr-auto"><%= message %></span>
-
-          <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close" data-delay="3000">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-      </div>
-    <% end %>
+<div class="d-flex justify-content-end">
+<% flash.each_with_index do |(type, message), index| %>
+  <div id="toast-<%= index %>"
+       class="alert alert-<%= bootstrap_class_for(type) %>"
+       role="alert"
+       data-controller="toasts">
+    <span><%= message %></span>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
-<% end %>-->
-
-
-
+<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   get "home", to: "sessions#index"
   post "connect", to: "sessions#create"
   get "disconnect", to: "sessions#destroy"
+  get "select_test_practitioner", to: "sessions#select_test_practitioner"
+  post "set_current_practitioner", to: "sessions#set_current_practitioner"
   get "dashboard", to: "dashboard#main"
   post "conditions", to: "conditions#create"
   get "conditions/:id/:status", to: "conditions#update_condition"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,17 @@
 Rails.application.routes.draw do
-  root 'sessions#index'
+  root "sessions#index"
   resources :personal_characteristics, only: [:new, :create, :destroy]
   resources :patients, only: [:index, :show]
-  get 'home', to: 'sessions#index'
-  post 'connect', to: 'sessions#create'
-  get 'disconnect', to: 'sessions#destroy'
-  get 'dashboard', to: 'dashboard#main'
-  post 'conditions', to: 'conditions#create'
-  get 'conditions/:id/:status', to: 'conditions#update_condition'
-  post 'tasks', to: 'tasks#create'
-  get 'tasks/:id/:status', to: 'tasks#update_task'
-  get 'poll_tasks', to: 'tasks#poll_tasks'
+  resources :organizations, only: [:create]
+  get "home", to: "sessions#index"
+  post "connect", to: "sessions#create"
+  get "disconnect", to: "sessions#destroy"
+  get "dashboard", to: "dashboard#main"
+  post "conditions", to: "conditions#create"
+  get "conditions/:id/:status", to: "conditions#update_condition"
+  post "tasks", to: "tasks#create"
+  get "tasks/:id/:status", to: "tasks#update_task"
+  get "poll_tasks", to: "tasks#poll_tasks"
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
This PR addresses the following:
- enables user to add new task recipient organizations ( with their contact details, requirement on the server base url)
- displays available organizations on the server
- removed the dependency of having to provide the recipient base url to connect to
- refactored how new task form
- enables user to select a test provider to use after connecting to the server
- restyle flash messages to be displayed as toast
- improve how poll status update notifications are displayed