### PR TITLE
Add Social Risk Assessments tab with QuestionnaireResponse display

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -102,6 +102,20 @@
   color: #4B5563;
 }
 
+.social-risk-assessment-item {
+  border-radius: 8px;
+}
+
+.social-risk-assessment-item.active {
+  background-color: #f8f9fa;
+  border-left: 3px solid #0d6efd !important;
+  color: #212529;
+}
+
+.social-risk-assessment-item.active .text-muted {
+  color: #6c757d !important;
+}
+
 .bg-gray-50-custom {
   background-color: #F9FAFB;
 }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,6 +13,7 @@ class DashboardController < ApplicationController
     if patient_id.present?
       set_personal_characteristics
       set_conditions
+      set_social_risk_assessments
       set_goals
       set_tasks
       set_service_requests
@@ -78,6 +79,16 @@ class DashboardController < ApplicationController
     else
       Rails.logger.info("Failed to set conditions: #{result}")
 
+      flash[:warning] = result
+    end
+  end
+
+  def set_social_risk_assessments
+    success, result = fetch_social_risk_assessments
+    if success
+      @social_risk_assessments = result
+    else
+      Rails.logger.info("Failed to set social risk assessments: #{result}")
       flash[:warning] = result
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,7 @@ module ApplicationHelper
   include GoalsHelper
   include GoalDefinitionsHelper
   include QuestionnaireHelper
+  include SocialRisksHelper
   include TasksHelper
   include ServiceRequestsHelper
 

--- a/app/helpers/social_risks_helper.rb
+++ b/app/helpers/social_risks_helper.rb
@@ -1,0 +1,27 @@
+module SocialRisksHelper
+  include SessionHelper
+
+  def fetch_social_risk_assessments
+    client = get_client
+    response = client.search(
+      FHIR::QuestionnaireResponse,
+      search: {
+        parameters: {
+          subject: "Patient/#{patient_id}",
+          _sort: "-authored",
+        },
+      },
+    )
+
+    if response.response[:code] == 200 && response.resource.is_a?(FHIR::Bundle)
+      entries = response.resource.entry&.map(&:resource) || []
+      [true, entries.map { |entry| QuestionnaireResponse.new(entry) }]
+    else
+      Rails.logger.error("Failed to fetch social risk assessments. Status: #{response.response[:code]} - #{response.response[:body]}")
+      [false, "Failed to fetch social risk assessments."]
+    end
+  rescue StandardError => e
+    Rails.logger.error(e.full_message)
+    [false, "Failed to fetch social risk assessments. #{e.message}"]
+  end
+end

--- a/app/models/questionnaire_response.rb
+++ b/app/models/questionnaire_response.rb
@@ -1,11 +1,124 @@
 class QuestionnaireResponse
   include ModelHelper
 
-  attr_reader :id, :fhir_resource
+  attr_reader :id, :fhir_resource, :questionnaire, :status, :authored, :author, :item_count, :answers, :sections
 
   def initialize(fhir_qr, fhir_client: nil)
     @id = fhir_qr.id
     @fhir_resource = fhir_qr
     remove_client_instances(@fhir_resource)
+    @questionnaire = fhir_qr.questionnaire
+    @status = fhir_qr.status
+    @authored = fhir_qr.authored
+    @author = fhir_qr.author&.display || fhir_qr.author&.reference
+    @item_count = fhir_qr.item&.count || 0
+    @answers = extract_answers(fhir_qr.item)
+    @sections = extract_sections(fhir_qr.item)
   end
+
+  def display_questionnaire
+    return "SDOH screening" if questionnaire.blank?
+
+    questionnaire.split("/").last&.delete_prefix("SDOHCC-Questionnaire")&.underscore&.humanize || questionnaire
+  end
+
+  def display_date
+    return "--" if authored.blank?
+
+    Time.zone.parse(authored).strftime("%b %-d, %Y")
+  rescue ArgumentError
+    authored
+  end
+
+  private
+
+  def extract_sections(items)
+    sections = Array(items).flat_map do |item|
+      child_items = Array(item.item)
+      if child_items.present?
+        child_sections = extract_sections(child_items)
+        answered_children = flatten_answer_items(child_items)
+        if answered_children.present? && child_sections.blank?
+          [{ title: item.text || item.linkId, answers: answered_children }]
+        elsif child_sections.present?
+          child_sections
+        else
+          []
+        end
+      elsif Array(item.answer).present?
+        answers = Array(item.answer).map { |answer| answer_hash(item, answer) }
+        [{ title: "Responses", answers: answers }]
+      else
+        []
+      end
+    end
+
+    # Collapse consecutive "Responses" sections into a single section
+    collapse_response_sections(sections)
+  end
+
+  def collapse_response_sections(sections)
+    return sections if sections.empty?
+
+    collapsed = []
+    response_answers = []
+
+    sections.each do |section|
+      if section[:title] == "Responses"
+        response_answers.concat(section[:answers])
+      else
+        # If we have accumulated response answers, add them as a single section
+        if response_answers.any?
+          collapsed << { title: "Responses", answers: response_answers }
+          response_answers = []
+        end
+        collapsed << section
+      end
+    end
+
+    # Don't forget any trailing response answers
+    if response_answers.any?
+      collapsed << { title: "Responses", answers: response_answers }
+    end
+
+    collapsed
+  end
+
+  def flatten_answer_items(items)
+    Array(items).flat_map do |item|
+      own_answers = Array(item.answer).map { |answer| answer_hash(item, answer) }
+      own_answers + flatten_answer_items(item.item)
+    end
+  end
+
+  def extract_answers(items)
+    Array(items).flat_map do |item|
+      child_answers = extract_answers(item.item)
+      own_answers = Array(item.answer).map do |answer|
+        answer_hash(item, answer)
+      end
+      own_answers + child_answers
+    end
+  end
+
+  def answer_hash(item, answer)
+    {
+      link_id: item.linkId,
+      text: item.text,
+      value: answer_value(answer),
+    }
+  end
+
+  def answer_value(answer)
+    answer.valueString ||
+      answer.valueBoolean ||
+      answer.valueInteger ||
+      answer.valueDecimal ||
+      answer.valueDate ||
+      answer.valueDateTime ||
+      answer.valueCoding&.display ||
+      answer.valueCoding&.code ||
+      answer.valueQuantity&.value
+  end
+
 end

--- a/app/views/dashboard/_social_risks.html.erb
+++ b/app/views/dashboard/_social_risks.html.erb
@@ -1,7 +1,7 @@
 <% if social_risks.blank? %>
   <p class="text-muted text-center py-4">No social risk assessments found for this patient.</p>
 <% else %>
-  <div class="d-flex gap-3 p-3" style="height: 600px;">
+  <div class="social-risk-assessments d-flex gap-3 p-3" style="height: 600px;">
 
     <%# ── Left Sidebar: Assessment List ─────────────────────────── %>
     <div class="d-flex flex-column" style="width: 320px; min-width: 320px;">
@@ -16,10 +16,10 @@
           %>
 
           <button type="button"
-                  class="list-group-item list-group-item-action <%= 'active' if is_active %> border-0 mb-2"
-                  style="border-radius: 8px; <%= 'background-color: #f8f9fa; border-left: 3px solid #0d6efd;' if is_active %>"
+                  class="social-risk-assessment-item list-group-item list-group-item-action <%= 'active' if is_active %> border-0 mb-2"
                   data-bs-toggle="tab"
                   data-bs-target="#assessment-<%= assessment.id %>"
+                  aria-selected="<%= is_active %>"
                   role="tab">
             <div class="d-flex flex-column gap-1">
               <div class="fw-semibold" style="font-size: 14px;">

--- a/app/views/dashboard/_social_risks.html.erb
+++ b/app/views/dashboard/_social_risks.html.erb
@@ -1,1 +1,136 @@
-Patient's social risk assessments will be displayed here.
+<% if social_risks.blank? %>
+  <p class="text-muted text-center py-4">No social risk assessments found for this patient.</p>
+<% else %>
+  <div class="d-flex gap-3 p-3" style="height: 600px;">
+
+    <%# ── Left Sidebar: Assessment List ─────────────────────────── %>
+    <div class="d-flex flex-column" style="width: 320px; min-width: 320px;">
+      <div class="mb-2">
+        <p class="text-muted small mb-0"><%= pluralize(social_risks.size, "assessment") %> on file</p>
+      </div>
+
+      <div class="list-group overflow-auto" style="flex: 1;">
+        <% social_risks.each_with_index do |assessment, index| %>
+          <%
+            is_active = index == 0
+          %>
+
+          <button type="button"
+                  class="list-group-item list-group-item-action <%= 'active' if is_active %> border-0 mb-2"
+                  style="border-radius: 8px; <%= 'background-color: #f8f9fa; border-left: 3px solid #0d6efd;' if is_active %>"
+                  data-bs-toggle="tab"
+                  data-bs-target="#assessment-<%= assessment.id %>"
+                  role="tab">
+            <div class="d-flex flex-column gap-1">
+              <div class="fw-semibold" style="font-size: 14px;">
+                <%= assessment.display_questionnaire %>
+              </div>
+
+              <div class="d-flex align-items-center gap-2 flex-wrap">
+                <span class="text-muted" style="font-size: 11px;">
+                  <i class="bi bi-calendar3 me-1"></i><%= assessment.display_date %>
+                </span>
+
+                <% if assessment.status.present? %>
+                  <% badge_class = assessment.status == "completed" ? "text-success bg-success" : "text-warning bg-warning" %>
+                  <span class="badge bg-opacity-10 <%= badge_class %>" style="font-size: 10px; font-weight: 500;">
+                    <%= assessment.status.titleize %>
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          </button>
+        <% end %>
+      </div>
+    </div>
+
+    <%# ── Right Panel: Assessment Details ───────────────────────── %>
+    <div class="flex-fill overflow-auto">
+      <div class="tab-content h-100">
+        <% social_risks.each_with_index do |assessment, index| %>
+          <div class="tab-pane fade <%= 'show active' if index == 0 %> h-100"
+               id="assessment-<%= assessment.id %>"
+               role="tabpanel">
+
+            <div class="card border shadow-none h-100" style="border-color: rgba(0,0,0,.08) !important; border-radius: 10px; overflow: hidden;">
+
+              <%# ── Card header ──────────────────────────────────────────── %>
+              <div class="card-header bg-white d-flex justify-content-between align-items-start gap-3 py-3 px-4"
+                   style="border-bottom: 1px solid rgba(0,0,0,.07);">
+                <div>
+                  <div class="d-flex align-items-center gap-2 mb-1">
+                    <h6 class="mb-0 fw-semibold" style="font-size: 15px;">
+                      <%= assessment.display_questionnaire %>
+                    </h6>
+                  </div>
+                  <div class="d-flex align-items-center gap-2 flex-wrap">
+                    <span class="text-muted" style="font-size: 12px;">
+                      <i class="bi bi-calendar3 me-1"></i><%= assessment.display_date %>
+                    </span>
+
+                    <% if assessment.status.present? %>
+                      <% badge_class = assessment.status == "completed" ? "text-success bg-success" : "text-warning bg-warning" %>
+                      <span class="badge bg-opacity-10 <%= badge_class %>" style="font-size: 11px; font-weight: 500;">
+                        <%= assessment.status.titleize %>
+                      </span>
+                    <% end %>
+                  </div>
+                </div>
+
+                <%= link_to "#fhir-resource-modal-#{assessment.id}",
+                      class: "btn btn-sm btn-outline-secondary",
+                      style: "font-size: 11px; white-space: nowrap;",
+                      data: { bs_toggle: "modal" } do %>
+                  FHIR <i class="bi bi-box-arrow-up-right ms-1"></i>
+                <% end %>
+
+                <% content_for :modals do %>
+                  <%= render "shared/fhir_resource_modal", resource: assessment %>
+                <% end %>
+              </div>
+
+              <%# ── Sections ─────────────────────────────────────────────── %>
+              <div class="overflow-auto" style="flex: 1;">
+                <% assessment.sections.each do |section| %>
+                  <div class="border-bottom" style="border-color: rgba(0,0,0,.06) !important;">
+
+                    <%# Section label (only shown if not generic "Responses") %>
+                    <% if section[:title].present? && section[:title] != "Responses" %>
+                      <div class="px-4 py-2 bg-light text-uppercase fw-semibold text-secondary"
+                           style="font-size: 10px; letter-spacing: .06em; border-bottom: 1px solid rgba(0,0,0,.06);">
+                        <%= section[:title] %>
+                      </div>
+                    <% end %>
+
+                    <table class="table table-sm mb-0" style="table-layout: auto;">
+                      <thead class="table-light">
+                        <tr>
+                          <th class="px-4 py-2 text-muted fw-normal" style="font-size: 11px; border-bottom: 1px solid rgba(0,0,0,.07);">Question</th>
+                          <th class="px-4 py-2 text-muted fw-normal" style="font-size: 11px; border-bottom: 1px solid rgba(0,0,0,.07);">Response</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <% section[:answers].each do |answer| %>
+                          <tr style="border-color: rgba(0,0,0,.05);">
+                            <td class="px-4 py-2 text-secondary" style="font-size: 13px; word-wrap: break-word;">
+                              <%= answer[:text] || answer[:link_id]&.humanize %>
+                            </td>
+                            <td class="px-4 py-2 fw-semibold" style="font-size: 13px;">
+                              <%= answer[:value] %>
+                            </td>
+                          </tr>
+                        <% end %>
+                      </tbody>
+                    </table>
+                  </div>
+                <% end %>
+              </div>
+
+            </div><!-- /.card -->
+          </div><!-- /.tab-pane -->
+        <% end %>
+      </div><!-- /.tab-content -->
+    </div><!-- /.flex-fill -->
+
+  </div><!-- /.d-flex -->
+<% end %>


### PR DESCRIPTION
## Summary
This PR adds a new Social Risk Assessments tab to the patient dashboard that displays QuestionnaireResponse resources

## Changes
- Created `QuestionnaireResponse` model to parse and display FHIR QuestionnaireResponse resources
- Added `SocialRisksHelper` to fetch QuestionnaireResponse resources from FHIR server
- Created two-panel UI with assessment list sidebar and detail view for responses
- Integrated support for PRAPARE and AHC HRSN screening questionnaires