### PR TITLE
Add organization capacity status checks to referral flow

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,39 @@
 class OrganizationsController < ApplicationController
   before_action :require_client
 
+  CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
+
+  # Maps codes from SDOHCC-CodeSystemTemporaryCodes (and legacy ad-hoc codes)
+  # to the statuses the front end understands.
+  CAPACITY_CODE_MAP = {
+    "capacity" => "available",
+    "no-capacity" => "at-capacity",
+    "at-capacity" => "at-capacity",
+    "no-capacity-has-waitlist" => "has-waitlist",
+    "has-waitlist" => "has-waitlist",
+  }.freeze
+
+  def check_capacity
+    client = get_client
+    org_id = params[:id]
+    Rails.logger.info("[CHECK_CAPACITY] Org ID: #{org_id}")
+
+    bundle = client.search(FHIR::HealthcareService, search: { parameters: { organization: org_id } }).resource
+    services = bundle&.entry&.map(&:resource)&.compact || []
+    Rails.logger.info("[CHECK_CAPACITY] Found #{services.size} HealthcareService(s): #{services.map(&:id)}")
+
+    # Prefer the first service that actually carries a capacity extension
+    extension = services.filter_map { |s| s.extension&.find { |e| e.url == CAPACITY_EXTENSION_URL } }.first
+    code = extension&.valueCode || extension&.valueCodeableConcept&.coding&.first&.code
+    capacity = CAPACITY_CODE_MAP[code] || "unknown"
+    Rails.logger.info("[CHECK_CAPACITY] Raw code: #{code.inspect}, normalized capacity: #{capacity}")
+
+    render json: { capacity: capacity }
+  rescue => e
+    Rails.logger.error("[CHECK_CAPACITY] ERROR: #{e.full_message}")
+    render json: { capacity: "unknown", error: e.message }, status: 502
+  end
+
   def create
     org = FHIR::Organization.new(
       active: true,

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,14 +3,16 @@ class OrganizationsController < ApplicationController
 
   CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
 
-  # Maps codes from SDOHCC-CodeSystemTemporaryCodes (and legacy ad-hoc codes)
-  # to the statuses the front end understands.
+  # The four concepts bound to SDOHCC-ValueSetCapacityStatus, mapped to the
+  # statuses the front end understands. These are the only capacity codes in
+  # SDOHCC-CodeSystemTemporaryCodes: "at-capacity" and "no-capacity-has-waitlist"
+  # were never real codes and are deliberately absent, so off-spec data surfaces
+  # as "unknown" instead of being silently accepted.
   CAPACITY_CODE_MAP = {
     "capacity" => "available",
     "no-capacity" => "at-capacity",
-    "at-capacity" => "at-capacity",
-    "no-capacity-has-waitlist" => "has-waitlist",
-    "has-waitlist" => "has-waitlist",
+    "waitlist" => "has-waitlist",
+    "additional-assessment-required" => "assessment-required",
   }.freeze
 
   def check_capacity
@@ -24,7 +26,10 @@ class OrganizationsController < ApplicationController
 
     # Prefer the first service that actually carries a capacity extension
     extension = services.filter_map { |s| s.extension&.find { |e| e.url == CAPACITY_EXTENSION_URL } }.first
-    code = extension&.valueCode || extension&.valueCodeableConcept&.coding&.first&.code
+    # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension:
+    # capacityStatus is 1..1 and Extension.value[x] is prohibited (0..0).
+    capacity_status_extension = extension&.extension&.find { |e| e.url == "capacityStatus" }
+    code = capacity_status_extension&.valueCodeableConcept&.coding&.first&.code
     capacity = CAPACITY_CODE_MAP[code] || "unknown"
     Rails.logger.info("[CHECK_CAPACITY] Raw code: #{code.inspect}, normalized capacity: #{capacity}")
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -20,7 +20,10 @@ class OrganizationsController < ApplicationController
     org_id = params[:id]
     Rails.logger.info("[CHECK_CAPACITY] Org ID: #{org_id}")
 
-    bundle = client.search(FHIR::HealthcareService, search: { parameters: { organization: org_id } }).resource
+    search_parameters = { organization: org_id }
+    search_parameters["service-category"] = params[:category] if params[:category].present?
+
+    bundle = client.search(FHIR::HealthcareService, search: { parameters: search_parameters }).resource
     services = bundle&.entry&.map(&:resource)&.compact || []
     Rails.logger.info("[CHECK_CAPACITY] Found #{services.size} HealthcareService(s): #{services.map(&:id)}")
 

--- a/app/javascript/controllers/capacity_controller.js
+++ b/app/javascript/controllers/capacity_controller.js
@@ -12,27 +12,28 @@ export default class extends Controller {
     if (!badge) return;
 
     badge.textContent = "Checking…";
-    badge.classList.remove("bg-success", "bg-danger", "bg-warning", "bg-secondary");
+    badge.classList.remove("bg-success", "bg-danger", "bg-warning", "bg-info", "bg-secondary");
 
+    // Fail closed: anything not explicitly recognized reads as Unknown, never
+    // as Available.
+    const UNKNOWN = { text: "Unknown", cls: "bg-secondary" };
+    const STATUSES = {
+      "available": { text: "Available", cls: "bg-success" },
+      "at-capacity": { text: "At Capacity", cls: "bg-danger" },
+      "has-waitlist": { text: "Has Waitlist", cls: "bg-warning" },
+      "assessment-required": { text: "Assessment Required", cls: "bg-info" },
+      "unknown": UNKNOWN,
+    };
+
+    let status = UNKNOWN;
     try {
       const { capacity } = await fetch(`/organizations/${orgId}/check_capacity`).then(r => r.json());
-
-      if (capacity === "at-capacity") {
-        badge.textContent = "At Capacity";
-        badge.classList.add("bg-danger");
-      } else if (capacity === "has-waitlist") {
-        badge.textContent = "Has Waitlist";
-        badge.classList.add("bg-warning");
-      } else if (capacity === "unknown") {
-        badge.textContent = "Unknown";
-        badge.classList.add("bg-secondary");
-      } else {
-        badge.textContent = "Available";
-        badge.classList.add("bg-success");
-      }
+      status = STATUSES[capacity] || UNKNOWN;
     } catch (err) {
-      badge.textContent = "Unknown";
-      badge.classList.add("bg-secondary");
+      status = UNKNOWN;
     }
+
+    badge.textContent = status.text;
+    badge.classList.add(status.cls);
   }
 }

--- a/app/javascript/controllers/capacity_controller.js
+++ b/app/javascript/controllers/capacity_controller.js
@@ -1,0 +1,38 @@
+// app/javascript/controllers/capacity_controller.js
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["badge"];
+
+  async check(e) {
+    const orgId = e.currentTarget.dataset.orgId;
+    if (!orgId) return;
+
+    const badge = this.badgeTargets.find(b => b.dataset.orgId === orgId);
+    if (!badge) return;
+
+    badge.textContent = "Checking…";
+    badge.classList.remove("bg-success", "bg-danger", "bg-warning", "bg-secondary");
+
+    try {
+      const { capacity } = await fetch(`/organizations/${orgId}/check_capacity`).then(r => r.json());
+
+      if (capacity === "at-capacity") {
+        badge.textContent = "At Capacity";
+        badge.classList.add("bg-danger");
+      } else if (capacity === "has-waitlist") {
+        badge.textContent = "Has Waitlist";
+        badge.classList.add("bg-warning");
+      } else if (capacity === "unknown") {
+        badge.textContent = "Unknown";
+        badge.classList.add("bg-secondary");
+      } else {
+        badge.textContent = "Available";
+        badge.classList.add("bg-success");
+      }
+    } catch (err) {
+      badge.textContent = "Unknown";
+      badge.classList.add("bg-secondary");
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("toasts", ToastsController)
 
 import ConditionsController from "./conditions_controller"
 application.register("conditions", ConditionsController)
+
+import CapacityController from "./capacity_controller"
+application.register("capacity", CapacityController)

--- a/app/javascript/controllers/taskform_controller.js
+++ b/app/javascript/controllers/taskform_controller.js
@@ -14,6 +14,9 @@ export default class extends Controller {
     "performer",
     "consent",
     "submitButton",
+    "capacityBadge",
+    "blockedAlert",
+    "waitlistAlert",
   ];
 
   connect() {
@@ -95,5 +98,52 @@ export default class extends Controller {
     const date = new Date();
     date.setDate(date.getDate() + Math.floor(Math.random() * 365) + 1);
     dateElement.valueAsDate = date;
+  }
+
+  async checkCapacity() {
+    const orgId = this.performerTarget.value
+    if (!orgId) return
+
+    let capacity = "unknown"
+    try {
+      const data = await fetch(`/organizations/${orgId}/check_capacity`).then(r => r.json())
+      capacity = data.capacity
+    } catch (err) {
+      console.error("Capacity check failed", err)
+    }
+
+    this.capacityBadgeTarget.classList.remove("d-none", "bg-success", "bg-danger", "bg-warning", "bg-secondary")
+    this.blockedAlertTarget.classList.add("d-none")
+    this.waitlistAlertTarget.classList.add("d-none")
+    this.submitButtonTarget.disabled = false
+
+    if (capacity === "at-capacity") {
+      this.capacityBadgeTarget.textContent = "At Capacity"
+      this.capacityBadgeTarget.classList.add("bg-danger")
+      this.blockedAlertTarget.classList.remove("d-none")
+      this.submitButtonTarget.disabled = true
+    } else if (capacity === "has-waitlist") {
+      this.capacityBadgeTarget.textContent = "Has Waitlist"
+      this.capacityBadgeTarget.classList.add("bg-warning")
+      this.waitlistAlertTarget.classList.remove("d-none")
+      this.submitButtonTarget.disabled = true
+    } else if (capacity === "available") {
+      this.capacityBadgeTarget.textContent = "Capacity Available"
+      this.capacityBadgeTarget.classList.add("bg-success")
+    } else {
+      this.capacityBadgeTarget.textContent = "Capacity Unknown"
+      this.capacityBadgeTarget.classList.add("bg-secondary")
+    }
+  }
+
+  proceedWaitlist() {
+    this.waitlistAlertTarget.classList.add("d-none")
+    this.submitButtonTarget.disabled = false
+  }
+
+  cancelWaitlist() {
+    this.waitlistAlertTarget.classList.add("d-none")
+    this.performerTarget.value = ""
+    this.capacityBadgeTarget.classList.add("d-none")
   }
 }

--- a/app/javascript/controllers/taskform_controller.js
+++ b/app/javascript/controllers/taskform_controller.js
@@ -112,7 +112,7 @@ export default class extends Controller {
       console.error("Capacity check failed", err)
     }
 
-    this.capacityBadgeTarget.classList.remove("d-none", "bg-success", "bg-danger", "bg-warning", "bg-secondary")
+    this.capacityBadgeTarget.classList.remove("d-none", "bg-success", "bg-danger", "bg-warning", "bg-info", "bg-secondary")
     this.blockedAlertTarget.classList.add("d-none")
     this.waitlistAlertTarget.classList.add("d-none")
     this.submitButtonTarget.disabled = false
@@ -130,6 +130,9 @@ export default class extends Controller {
     } else if (capacity === "available") {
       this.capacityBadgeTarget.textContent = "Capacity Available"
       this.capacityBadgeTarget.classList.add("bg-success")
+    } else if (capacity === "assessment-required") {
+      this.capacityBadgeTarget.textContent = "Assessment Required"
+      this.capacityBadgeTarget.classList.add("bg-info")
     } else {
       this.capacityBadgeTarget.textContent = "Capacity Unknown"
       this.capacityBadgeTarget.classList.add("bg-secondary")

--- a/app/views/action_steps/_form_modal.html.erb
+++ b/app/views/action_steps/_form_modal.html.erb
@@ -42,7 +42,18 @@
                     <hr>
           <div class="mb-3">
             <%= f.label :performer_id, "Performer", class: "form-label" %>
-            <%= f.collection_select :performer_id, organizations, :id, :name, { prompt: 'Select Performer' }, { class: "form-select", data: { taskform_target: "performer" } } %>
+            <%= f.collection_select :performer_id, organizations, :id, :name, { prompt: 'Select Performer' }, { class: "form-select", data: { taskform_target: "performer", action: "change->taskform#checkCapacity" } } %>
+            <span class="badge ms-2 d-none" data-taskform-target="capacityBadge"></span>
+          </div>
+          <div class="alert alert-danger d-none mt-2" data-taskform-target="blockedAlert">
+            This organization is at capacity and cannot accept new referrals. Please select a different organization.
+          </div>
+          <div class="alert alert-warning d-none mt-2" data-taskform-target="waitlistAlert">
+            This organization has a waitlist. Do you want to proceed with the referral?
+            <div class="mt-2">
+              <button type="button" class="btn btn-sm btn-secondary" data-action="taskform#cancelWaitlist">Cancel</button>
+              <button type="button" class="btn btn-sm btn-primary" data-action="taskform#proceedWaitlist">Proceed</button>
+            </div>
           </div>
           <div class="mb-3">
             <%= f.label :consent, "Consent", class: "form-label" %>

--- a/app/views/dashboard/_referral_organizations.html.erb
+++ b/app/views/dashboard/_referral_organizations.html.erb
@@ -15,7 +15,7 @@
     <% elsif organizations.empty? %>
       <p class="text-center pb-4 text-muted">No organization found.</p>
     <% else %>
-      <table class="table table-sm text-center text-xs-custom fw-semibold">
+      <table class="table table-sm text-center text-xs-custom fw-semibold" data-controller="capacity">
         <thead class="text-xs-custom text-gray-700-custom text-uppercase bg-gray-50-custom">
           <tr>
             <th>Name</th>
@@ -23,6 +23,7 @@
             <th>Phone</th>
             <th>Email</th>
             <th>URL</th>
+            <th>Capacity</th>
             <th>FHIR Resource</th>
           </tr>
         </thead>
@@ -34,6 +35,10 @@
               <td><%= organization.phone %></td>
               <td><%= organization.email %></td>
               <td><%= organization.url %></td>
+              <td>
+                <span class="badge capacity-badge" data-capacity-target="badge" data-org-id="<%= organization.id %>">—</span>
+                <button type="button" class="btn btn-link btn-sm check-capacity-btn" data-action="capacity#check" data-org-id="<%= organization.id %>">Check Capacity</button>
+              </td>
               <td>
                 <%= link_to 'FHIR Resource', '#', data: { bs_toggle: 'modal', bs_target: "#fhir-resource-modal-#{organization.id}" } %>
                 <% content_for :modals do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :goals, only: [:create, :destroy]
   resources :patients, only: [:index, :show]
   resources :organizations, only: [:create]
+  get "/organizations/:id/check_capacity", to: "organizations#check_capacity", as: :check_capacity_organization
   get "home", to: "sessions#index"
   post "connect", to: "sessions#create"
   get "disconnect", to: "sessions#destroy"


### PR DESCRIPTION
Adds a check_capacity endpoint and Stimulus controller that reads the SDOHCC HealthcareService capacity extension, surfacing capacity on the dashboard and blocking/warning on at-capacity or waitlisted orgs during referral creation.