### PR TITLE
CFRID-951: Keep patient task submit button inside the form

### DIFF
--- a/app/views/patient_tasks/_form_modal.html.erb
+++ b/app/views/patient_tasks/_form_modal.html.erb
@@ -35,12 +35,12 @@
           
           
 
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <%= f.submit "Create & Send", class: "btn btn-primary" %>
+          </div>
+        <% end %>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <%= f.submit "Create & Send", class: "btn btn-primary" %>
-      </div>
-      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The modal-body closing </div> appeared before the form_with block ended, so the browser closed the <form> early and rendered the modal-footer and submit button outside it. Move the modal-body </div> after the block so the footer and submit button stay inside the form.
