### PR TITLE
CFRID-966: Task input/output plumbing

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -104,7 +104,7 @@ class DashboardController < ApplicationController
   end
 
   def set_tasks
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT)
     if success
       @active_referrals = result["active"] || []
       @completed_referrals = result["completed"] || []
@@ -114,7 +114,7 @@ class DashboardController < ApplicationController
       flash[:warning] = result
     end
 
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_PATIENT)
     if success
       @active_patient_tasks = result["active"] || []
       @completed_patient_tasks = result["completed"] || []

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -95,7 +95,7 @@ class GoalsController < ApplicationController
   ### Create a new goal ###
   def meta
     {
-      "profile": ["http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Goal"],
+      "profile": [FhirProfiles::GOAL],
     }
   end
 
@@ -116,7 +116,7 @@ class GoalsController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": params[:category],
             "display": params[:category]&.split("-")&.join(" ")&.titleize,
           },

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,8 +1,6 @@
 class OrganizationsController < ApplicationController
   before_action :require_client
 
-  CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
-
   # The four concepts bound to SDOHCC-ValueSetCapacityStatus, mapped to the
   # statuses the front end understands. These are the only capacity codes in
   # SDOHCC-CodeSystemTemporaryCodes: "at-capacity" and "no-capacity-has-waitlist"
@@ -28,7 +26,7 @@ class OrganizationsController < ApplicationController
     Rails.logger.info("[CHECK_CAPACITY] Found #{services.size} HealthcareService(s): #{services.map(&:id)}")
 
     # Prefer the first service that actually carries a capacity extension
-    extension = services.filter_map { |s| s.extension&.find { |e| e.url == CAPACITY_EXTENSION_URL } }.first
+    extension = services.filter_map { |s| s.extension&.find { |e| e.url == FhirProfiles::CAPACITY_STATUS_EXTENSION } }.first
     # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension:
     # capacityStatus is 1..1 and Extension.value[x] is prohibited (0..0).
     capacity_status_extension = extension&.extension&.find { |e| e.url == "capacityStatus" }

--- a/app/controllers/patient_tasks_controller.rb
+++ b/app/controllers/patient_tasks_controller.rb
@@ -90,7 +90,7 @@ class PatientTasksController < ApplicationController
   def patient_task_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient",
+        FhirProfiles::TASK_FOR_PATIENT,
       ],
     }
   end

--- a/app/controllers/personal_characteristics_controller.rb
+++ b/app/controllers/personal_characteristics_controller.rb
@@ -148,7 +148,7 @@ class PersonalCharacteristicsController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": "personal-characteristic"
           }
         ]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -78,7 +78,7 @@ class TasksController < ApplicationController
   def poll_referral_tasks
     saved_tasks = Rails.cache.read(tasks_key) || []
     Rails.cache.delete(tasks_key)
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT)
     if success
       @active_referrals = result["active"] || []
       @completed_referrals = result["completed"] || []
@@ -114,7 +114,7 @@ class TasksController < ApplicationController
   def task_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement",
+        FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT,
       ],
     }
   end
@@ -151,7 +151,7 @@ class TasksController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": "make-contact",  # Example: Replace with the correct code from SDOHCC Task for Patient
             "display": "Make Contact",
           },
@@ -163,7 +163,7 @@ class TasksController < ApplicationController
   def service_req_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ServiceRequest",
+        FhirProfiles::SERVICE_REQUEST,
       ],
     }
   end
@@ -182,7 +182,7 @@ class TasksController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": params[:category],
             "display": params[:category]&.titleize,
           },

--- a/app/helpers/condition_definitions_helper.rb
+++ b/app/helpers/condition_definitions_helper.rb
@@ -1,7 +1,7 @@
 # Helper constants valueset for Condition resource (health concern/ problem)
 module ConditionDefinitionsHelper
-  CONDITION_PROFILE = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition".freeze
-  CATEGORY_SDOH_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+  CONDITION_PROFILE = FhirProfiles::CONDITION
+  CATEGORY_SDOH_CODE_SYSTEM = FhirProfiles::TEMPORARY_CODE_SYSTEM
   CONDITION_CATEGORY_US_CORE_CODE_SYSTEM = "http://hl7.org/fhir/us/core/CodeSystem/condition-category".freeze
   SNOMED_CODE_SYSTEM = "http://snomed.info/sct".freeze
   ICD_10_CODE_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm".freeze

--- a/app/helpers/personal_characteristics_definitions_helper.rb
+++ b/app/helpers/personal_characteristics_definitions_helper.rb
@@ -1,6 +1,6 @@
 module PersonalCharacteristicsDefinitionsHelper
   # Code Systems
-  REPORTED_METHODS_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+  REPORTED_METHODS_SYSTEM = FhirProfiles::TEMPORARY_CODE_SYSTEM
 
   PERSONAL_PRONOUNS_OTHER = "OTH".freeze
   SEX_GENDER_OTHER = "LA32969-0".freeze
@@ -23,12 +23,12 @@ module PersonalCharacteristicsDefinitionsHelper
   }.freeze
 
   PERSONAL_CHARACTERISTICS_PROFILES = {
-    race: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRaceOMB",
-    ethnicity: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationEthnicityOMB",
-    gender_identity: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationGenderIdentity",
-    recorded_sex_gender: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRecordedSexGender",
-    sexual_orientation: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationSexualOrientation",
-    personal_pronouns: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationPersonalPronouns"
+    race: FhirProfiles::OBSERVATION_RACE_OMB,
+    ethnicity: FhirProfiles::OBSERVATION_ETHNICITY_OMB,
+    gender_identity: FhirProfiles::OBSERVATION_GENDER_IDENTITY,
+    recorded_sex_gender: FhirProfiles::OBSERVATION_RECORDED_SEX_GENDER,
+    sexual_orientation: FhirProfiles::OBSERVATION_SEXUAL_ORIENTATION,
+    personal_pronouns: FhirProfiles::OBSERVATION_PERSONAL_PRONOUNS
   }.freeze
 
   PERSONAL_PRONOUNS = [

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -42,7 +42,7 @@ class Condition
   def get_category_display(category)
     type =
       category
-        &.find { |c| c.coding&.first&.system == "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes" }
+        &.find { |c| c.coding&.first&.system == FhirProfiles::TEMPORARY_CODE_SYSTEM }
         &.coding
         &.first
     type&.display || type&.code&.gsub("-", " ")&.titleize

--- a/app/models/fhir_profiles.rb
+++ b/app/models/fhir_profiles.rb
@@ -1,0 +1,64 @@
+# Canonical URLs for the FHIR artifacts this client reads and writes.
+#
+# Every profile, extension and temporary-code-system URL used anywhere in the
+# application is declared here so that a spec change is a one-line edit and so
+# that no two call sites can disagree about a canonical URL. Nothing outside
+# this module should carry one as a string literal.
+#
+# SDOH artifacts are from HL7 FHIR Implementation Guide "Social Determinants of
+# Health Clinical Care" (hl7.fhir.us.sdoh-clinicalcare), STU 3 continuous build.
+module FhirProfiles
+  # --- SDOH Clinical Care profiles ---
+
+  # SDOHCC Task For Referral Management
+  TASK_FOR_REFERRAL_MANAGEMENT = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement".freeze
+  # SDOHCC Task For Patient
+  TASK_FOR_PATIENT = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient".freeze
+  # SDOHCC ServiceRequest
+  SERVICE_REQUEST = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ServiceRequest".freeze
+  # SDOHCC Procedure
+  PROCEDURE = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Procedure".freeze
+  # SDOHCC Goal
+  GOAL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Goal".freeze
+  # SDOHCC Condition
+  CONDITION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition".freeze
+
+  # SDOHCC Observation Race OMB
+  OBSERVATION_RACE_OMB = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRaceOMB".freeze
+  # SDOHCC Observation Ethnicity OMB
+  OBSERVATION_ETHNICITY_OMB = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationEthnicityOMB".freeze
+  # SDOHCC Observation Gender Identity
+  OBSERVATION_GENDER_IDENTITY = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationGenderIdentity".freeze
+  # SDOHCC Observation Recorded Sex Gender
+  OBSERVATION_RECORDED_SEX_GENDER = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRecordedSexGender".freeze
+  # SDOHCC Observation Sexual Orientation
+  OBSERVATION_SEXUAL_ORIENTATION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationSexualOrientation".freeze
+  # SDOHCC Observation Personal Pronouns
+  OBSERVATION_PERSONAL_PRONOUNS = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationPersonalPronouns".freeze
+
+  # --- SDOH Clinical Care extensions ---
+
+  # SDOHCC Extension Healthcare Service Capacity Status
+  CAPACITY_STATUS_EXTENSION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
+
+  # --- SDOH Clinical Care code system ---
+
+  # SDOHCC CodeSystem Temporary Codes
+  TEMPORARY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+
+  # The two SDOHCC-CodeSystemTemporaryCodes concepts that discriminate the
+  # Task.input and Task.output slices in SDOHCC-TaskForReferralManagement.
+  ADDITIONAL_CONTENT_CODE = "additional-content".freeze
+  ADDITIONAL_CONTENT_DISPLAY = "Additional Content".freeze
+  RESULTING_ACTIVITY_CODE = "resulting-activity".freeze
+  RESULTING_ACTIVITY_DISPLAY = "Resulting Activity".freeze
+
+  # --- US Core extensions (hl7.fhir.us.core) ---
+
+  # US Core Race Extension
+  US_CORE_RACE_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race".freeze
+  # US Core Ethnicity Extension
+  US_CORE_ETHNICITY_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity".freeze
+  # US Core Birth Sex Extension
+  US_CORE_BIRTHSEX_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex".freeze
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -43,19 +43,19 @@ class Patient
 
     fhir_patient_extension_arr&.each do |ext|
       case ext&.url
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+      when FhirProfiles::US_CORE_RACE_EXTENSION
         ext.extension&.each do |race_ext|
           if race_ext&.url == 'ombCategory' && race_ext&.valueCoding&.display
             characteristics[:race] << race_ext.valueCoding.display
           end
         end
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+      when FhirProfiles::US_CORE_ETHNICITY_EXTENSION
         ext.extension&.each do |ethnicity_ext|
           if ethnicity_ext&.url == 'ombCategory' && ethnicity_ext&.valueCoding&.display
             characteristics[:ethnicity] << ethnicity_ext.valueCoding.display
           end
         end
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+      when FhirProfiles::US_CORE_BIRTHSEX_EXTENSION
         characteristics[:birthsex] = ext.valueCode
       end
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task
   include ModelHelper
 
-  attr_reader :id, :status, :focus, :owner_reference, :owner_name, :outcome, :outcome_type, :fhir_resource, :code
+  attr_reader :id, :status, :focus, :owner_reference, :owner_name, :outputs, :inputs, :fhir_resource, :code
 
   def initialize(fhir_task, fhir_client: nil)
     @id = fhir_task.id
@@ -11,11 +11,45 @@ class Task
     @focus = get_focus(fhir_task.focus, fhir_client)
     @owner_reference = fhir_task.owner&.reference
     @owner_name = fhir_task.owner&.display
-    @outcome = get_outcome(fhir_task.output&.first, fhir_client)
+    @outputs = build_io_entries(fhir_task.output, fhir_client)
+    # Inputs are parsed but their references are deliberately not resolved: no
+    # view renders Task.input yet, and resolving one would cost a server read
+    # per entry on every dashboard refresh. Pass the client here when one does.
+    @inputs = build_io_entries(fhir_task.input, nil)
     @code = get_coding(fhir_task.code&.coding&.first)
   end
 
+  # Task.output entries under the resulting-activity code: what was done.
+  def performed_activity_outputs
+    outputs.select(&:performed_activity?)
+  end
+
+  # Task.output entries under the additional-content code: enrollment status,
+  # assessments, goals, conditions and the like.
+  def additional_content_outputs
+    outputs.select(&:additional_content?)
+  end
+
+  # Task.input entries under the additional-content code.
+  def additional_content_inputs
+    inputs.select(&:additional_content?)
+  end
+
+  # The first resulting-activity output. Kept so callers written against the
+  # single-outcome API keep working while they move to #outputs.
+  def outcome
+    performed_activity_outputs.first&.then { |entry| entry.resource || entry.value }
+  end
+
+  def outcome_type
+    performed_activity_outputs.first&.display_type
+  end
+
   private
+
+  def build_io_entries(entries, fhir_client)
+    Array(entries).filter_map { |entry| TaskIoEntry.build(entry, fhir_client) }
+  end
 
   def get_focus(focus, fhir_client)
     return if focus.nil?
@@ -25,46 +59,6 @@ class Task
     # sometimes for some reason read returns FHIR::Bundle
     fhir_focus = fhir_focus&.entry&.first&.resource if fhir_focus.is_a?(FHIR::Bundle)
     ServiceRequest.new(fhir_focus, fhir_client: fhir_client) if fhir_focus
-  end
-
-  def get_outcome(outcome, fhir_client)
-    return if outcome.nil?
-
-    # if output is a reference, try to resolve it
-    if outcome.valueReference.present?
-      type = outcome.valueReference&.reference.split("/").first
-      id = outcome.valueReference&.reference.split("/").last
-
-      Rails.logger.info("outcome type:  #{type} id: #{id}")
-
-      case type
-      when "Procedure"
-        @outcome_type = "Procedure"
-        fhir_outcome = fhir_client.read(FHIR::Procedure, id).resource
-        Procedure.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      when "QuestionnaireResponse"
-        @outcome_type = "QuestionnaireResponse"
-        fhir_outcome = fhir_client.read(FHIR::QuestionnaireResponse, id).resource
-        QuestionnaireResponse.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      when "DocumentReference"
-        @outcome_type = "DocumentReference"
-        fhir_outcome = fhir_client.read(FHIR::DocumentReference, id).resource
-        DocumentReference.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      else
-        nil
-      end
-
-    # codes and markdown just returned as strings
-    elsif outcome.valueCodeableConcept.present?
-      outcome.valueCodeableConcept.coding&.first&.code&.titleize
-      @outcome_type = outcome.type&.coding&.first&.code&.titleize
-    elsif outcome.valueMarkdown.present?
-      outcome.valueMarkdown
-      @outcome_type = "markdown"
-    end
-
-
-
   end
 
   def get_coding(coding)

--- a/app/models/task_io_entry.rb
+++ b/app/models/task_io_entry.rb
@@ -1,0 +1,205 @@
+# One entry of Task.input or Task.output.
+#
+# SDOHCC-TaskForReferralManagement slices Task.output on both Task.output.type
+# and the type of Task.output.value[x], and slices Task.input on
+# Task.input.type. Both slicings are open and every slice is 0..*, so one
+# completed referral can carry a Procedure reference, a procedure code and any
+# number of additional-content references at the same time. Reading only the
+# first entry, or assuming a reference points at a Procedure, loses data.
+#
+# This wraps a single entry: which slice it belongs to, the referenced resource
+# or literal value it carries, and enough type information for a view to render
+# it without going back to the server.
+class TaskIoEntry
+  attr_reader :slice, :type_code, :type_display, :value_kind, :reference,
+              :resource_type, :resource_id, :resource, :value
+
+  def self.build(fhir_entry, fhir_client = nil)
+    return if fhir_entry.nil?
+
+    new(fhir_entry, fhir_client)
+  end
+
+  # Splits "Procedure/123", an absolute URL or a versioned reference into its
+  # resource type and id. Contained ("#p1") and urn: references have no type and
+  # yield [nil, nil], as does anything that does not look like a resource type.
+  def self.parse_reference(reference)
+    return [nil, nil] if reference.blank?
+
+    path = reference.to_s.split("?").first.to_s
+    return [nil, nil] if path.start_with?("#", "urn:")
+
+    segments = path.split("/").reject(&:blank?)
+    history_at = segments.index("_history")
+    segments = segments[0...history_at] if history_at
+    type = segments[-2]
+    id = segments[-1]
+    return [nil, nil] unless type.to_s.match?(/\A[A-Z][A-Za-z]+\z/)
+
+    [type, id]
+  end
+
+  def initialize(fhir_entry, fhir_client = nil)
+    @type_code = read_type_code(fhir_entry.type)
+    @type_display = read_type_display(fhir_entry.type)
+    @value_kind = read_value_kind(fhir_entry)
+    @reference = fhir_entry.valueReference&.reference
+    @resource_type, @resource_id = self.class.parse_reference(@reference)
+    @slice = read_slice
+    @value = read_value(fhir_entry)
+    @resource = resolve(fhir_client)
+  end
+
+  # PerformedActivityReference and PerformedActivityCode both sit under the
+  # resulting-activity code; either one describes what was actually done.
+  def performed_activity?
+    slice == :performed_activity_reference || slice == :performed_activity_code
+  end
+
+  def additional_content?
+    slice == :additional_content
+  end
+
+  def reference?
+    value_kind == :reference
+  end
+
+  def resolved?
+    resource.present?
+  end
+
+  # What a view labels this entry with: the referenced resource's type where
+  # there is one, otherwise the slice's own display.
+  def display_type
+    case value_kind
+    when :reference then resource_type.presence || type_display
+    when :markdown then "markdown"
+    else type_display
+    end
+  end
+
+  def id
+    resource&.id || resource_id
+  end
+
+  private
+
+  # The temporary-codes coding is the one the profile discriminates on; fall
+  # back to the first coding so an off-spec entry still describes itself.
+  def read_type_code(type)
+    codings = Array(type&.coding)
+    coding = codings.find { |c| c&.system == FhirProfiles::TEMPORARY_CODE_SYSTEM } || codings.first
+    coding&.code
+  end
+
+  def read_type_display(type)
+    return if type_code.blank?
+
+    type_code.titleize
+  end
+
+  def read_value_kind(fhir_entry)
+    return :reference if fhir_entry.valueReference&.reference.present?
+    return :codeable_concept if fhir_entry.valueCodeableConcept.present?
+    return :markdown if fhir_entry.valueMarkdown.present?
+    return :string if fhir_entry.valueString.present?
+
+    :other
+  end
+
+  def read_slice
+    case type_code
+    when FhirProfiles::RESULTING_ACTIVITY_CODE
+      case value_kind
+      when :reference then :performed_activity_reference
+      when :codeable_concept then :performed_activity_code
+      else :unknown
+      end
+    when FhirProfiles::ADDITIONAL_CONTENT_CODE
+      :additional_content
+    else
+      :unknown
+    end
+  end
+
+  # The value, not the name of the slice it arrived in.
+  def read_value(fhir_entry)
+    case value_kind
+    when :codeable_concept
+      coding = fhir_entry.valueCodeableConcept&.coding&.first
+      coding&.display.presence || coding&.code&.titleize
+    when :markdown
+      fhir_entry.valueMarkdown
+    when :string
+      fhir_entry.valueString
+    end
+  end
+
+  # Resolved by the resource type in the reference itself. Assuming Procedure
+  # fetched an Observation as a Procedure and silently dropped it.
+  def resolve(fhir_client)
+    return if fhir_client.nil? || resource_type.blank? || resource_id.blank?
+
+    fhir_resource = read_fhir_resource(fhir_client)
+    return if fhir_resource.nil?
+
+    wrap(fhir_resource, fhir_client)
+  rescue => e
+    Rails.logger.warn("Unable to resolve Task #{type_code} entry #{reference}: #{e.message}")
+    nil
+  end
+
+  def read_fhir_resource(fhir_client)
+    fhir_class = fhir_class_for(resource_type)
+    if fhir_class.nil?
+      Rails.logger.info("Task #{type_code} entry references unknown resource type #{resource_type}")
+      return
+    end
+
+    Rails.logger.info("Task #{type_code} entry: reading #{resource_type}/#{resource_id}")
+    fhir_resource = fhir_client.read(fhir_class, resource_id).resource
+    # sometimes for some reason read returns FHIR::Bundle
+    fhir_resource = fhir_resource&.entry&.first&.resource if fhir_resource.is_a?(FHIR::Bundle)
+    fhir_resource if fhir_resource.is_a?(fhir_class)
+  end
+
+  def fhir_class_for(type)
+    return unless FHIR.const_defined?(type, false)
+
+    fhir_class = FHIR.const_get(type, false)
+    fhir_class if fhir_class.is_a?(Class) && fhir_class <= FHIR::Model
+  end
+
+  # A type with no model of its own is still shown, as raw FHIR, rather than
+  # being dropped.
+  def wrap(fhir_resource, fhir_client)
+    case resource_type
+    when "Procedure" then Procedure.new(fhir_resource, fhir_client: fhir_client)
+    when "Observation" then Observation.new(fhir_resource)
+    when "Condition" then Condition.new(fhir_resource, fhir_client: fhir_client)
+    when "Goal" then Goal.new(fhir_resource, fhir_client: fhir_client)
+    when "QuestionnaireResponse" then QuestionnaireResponse.new(fhir_resource, fhir_client: fhir_client)
+    when "DocumentReference" then DocumentReference.new(fhir_resource, fhir_client: fhir_client)
+    else GenericResource.new(fhir_resource)
+    end
+  end
+
+  # A referenced resource this client has no model for: enough for a view to
+  # link to it and for shared/_fhir_resource_modal to render it.
+  class GenericResource
+    include ModelHelper
+
+    attr_reader :id, :resource_type, :fhir_resource
+
+    def initialize(fhir_resource)
+      @fhir_resource = fhir_resource
+      remove_client_instances(@fhir_resource)
+      @id = fhir_resource.id
+      @resource_type = fhir_resource.resourceType
+    end
+
+    def resourceType
+      resource_type
+    end
+  end
+end

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -90,10 +90,27 @@
 
             <% if type == "completed" %>
               <td>
-                <% if referral&.outcome&.id.present? %>
-                  <%= link_to referral.outcome_type, "#referral-procedure-modal-#{referral.outcome&.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "action_steps/procedure_modal", resource: referral.outcome %>
+                <% if referral&.outputs.present? %>
+                  <% referral.outputs.each_with_index do |output, index| %>
+                    <% if index.positive? %>, <% end %>
+                    <% if output.resource.blank? && output.value.blank? %>
+                      <span class="small-text"><%= output.display_type %></span>
+                    <% elsif output.resource.blank? %>
+                      <%= link_to output.display_type, "#string-modal-#{referral.id}-#{index}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/string_modal", { id: "#{referral.id}-#{index}", resource: output.value } %>
+                      <% end %>
+                    <% elsif output.resource_type == "Procedure" %>
+                      <%= link_to output.display_type, "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "action_steps/procedure_modal", resource: output.resource %>
+                      <% end %>
+                    <% else %>
+                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/fhir_resource_modal", resource: output.resource %>
+                      <% end %>
+                    <% end %>
                   <% end %>
                 <% else %>
                   --

--- a/app/views/patient_tasks/_table.html.erb
+++ b/app/views/patient_tasks/_table.html.erb
@@ -91,15 +91,22 @@
 
             <% if type == "completed" %>
               <td>
-                <% if task.outcome.is_a? String %>
-                  <%= link_to task.outcome_type, "#string-modal-#{task.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "shared/string_modal", {id: task.id, resource: task.outcome} %>
-                  <% end %>
-                <% elsif task.outcome&.id.present? %>
-                  <%= link_to task.outcome_type, "#fhir-resource-modal-#{task.outcome&.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "shared/fhir_resource_modal", resource: task.outcome %>
+                <% if task.outputs.present? %>
+                  <% task.outputs.each_with_index do |output, index| %>
+                    <% if index.positive? %>, <% end %>
+                    <% if output.resource.present? %>
+                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/fhir_resource_modal", resource: output.resource %>
+                      <% end %>
+                    <% elsif output.value.present? %>
+                      <%= link_to output.display_type, "#string-modal-#{task.id}-#{index}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/string_modal", { id: "#{task.id}-#{index}", resource: output.value } %>
+                      <% end %>
+                    <% else %>
+                      <span class="small-text"><%= output.display_type %></span>
+                    <% end %>
                   <% end %>
                 <% else %>
                   --


### PR DESCRIPTION
## Problem

A conformant multi-entry `Task.output` is a heterogeneous list: any number of `resulting-activity` entries (a `Reference(SDOHCCProcedure)` or a US Core procedure code) plus any number of `additional-content` entries pointing at an enrollment-status, assessment or screening Observation, Goal, Condition, QuestionnaireResponse or CarePlan. The slicing is open, every slice is `0..*`, and a Procedure never travels through `AdditionalContent`.

The client read only the first entry, so anything past it was invisible.

## Change

Adds a `TaskIoEntry` value object plus `Task#outputs` and `Task#inputs`, and a `FhirProfiles` module holding the profile canonical URLs.

This client only reads output — it does not write it — so no write path is introduced here.

Based on `upstream/master`; RS PRs #10 and #11 are merged upstream, so the branch is clean.

## Verification

Against the shared EHR server:

- A referral completed in the CBO UI renders identically to master in all three clients.
- A hand-added `additional-content` Observation output then renders alongside it in all three, with `GETTING: <EHR>/Observation/95426bf2…` in the log rather than a Procedure read.
- A task already carrying an Observation output kept it when completed, because the CBO client's `append_output` appended the Procedure — on master that assignment destroyed it.

All four created or modified resources validate with zero errors against `hl7.fhir.us.sdoh-clinicalcare#3.0.0` using validator 6.10.2 on Java 17. One Procedure requires `-sct us`, because the seeded ServiceRequest's code is a US Extension SNOMED concept.