### PR TITLE
CFRID-970: Protective factors are additive to the SDOH domain (STU 3)

### DIFF
--- a/app/controllers/conditions_controller.rb
+++ b/app/controllers/conditions_controller.rb
@@ -115,8 +115,13 @@ class ConditionsController < ApplicationController
     }
   end
 
+  # Condition.category is sliced by SDOHCC-Condition. Every condition this app
+  # creates carries the US Core problem-list-item/health-concern code
+  # (SDOH-Con-2) and the US Core "sdoh" screening-assessment code (SDOH-Con-3).
+  # category[SDOHCC] is 0..*, so the SDOH domain and protective-factor are
+  # appended as separate repeats rather than competing for one slot (cond-4).
   def category
-    [
+    categories = [
       {
         "coding": [
           {
@@ -129,13 +134,43 @@ class ConditionsController < ApplicationController
       {
         "coding": [
           {
-            "system": CATEGORY_SDOH_CODE_SYSTEM,
-            "code": params[:category],
-            "display": params[:category]&.titleize
+            "system": CATEGORY_SCREENING_ASSESSMENT_CODE_SYSTEM,
+            "code": CATEGORY_SDOH,
+            "display": "SDOH"
           }
         ]
       }
     ]
+
+    if params[:category].present?
+      categories << {
+        "coding": [
+          {
+            "system": CATEGORY_SDOH_CODE_SYSTEM,
+            "code": params[:category],
+            "display": params[:category].titleize
+          }
+        ]
+      }
+    end
+
+    if protective_factor?
+      categories << {
+        "coding": [
+          {
+            "system": CATEGORY_SDOH_CODE_SYSTEM,
+            "code": CATEGORY_PROTECTIVE_FACTOR,
+            "display": "Protective Factor"
+          }
+        ]
+      }
+    end
+
+    categories
+  end
+
+  def protective_factor?
+    ActiveModel::Type::Boolean.new.cast(params[:protective_factor]).present?
   end
 
   def code

--- a/app/helpers/condition_definitions_helper.rb
+++ b/app/helpers/condition_definitions_helper.rb
@@ -6,6 +6,22 @@ module ConditionDefinitionsHelper
   SNOMED_CODE_SYSTEM = "http://snomed.info/sct".freeze
   ICD_10_CODE_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm".freeze
 
+  # SDOHCC-Condition slices Condition.category into problem-or-health-concern,
+  # screening-assessment and SDOHCC (0..*). SDOH-Con-3 requires at least one
+  # category to be the US Core "sdoh" screening-assessment code.
+  CATEGORY_SCREENING_ASSESSMENT_CODE_SYSTEM = "http://hl7.org/fhir/us/core/CodeSystem/us-core-category".freeze
+  CATEGORY_SDOH = "sdoh".freeze
+
+  # protective-factor is a member of SDOHCC ValueSet SDOH Category, bound to the
+  # same repeating category[SDOHCC] slice as the SDOH domains, so it is additive
+  # to a domain rather than an alternative to one (SDOHCC Condition, cond-4).
+  CATEGORY_PROTECTIVE_FACTOR = "protective-factor".freeze
+
+  # Extensible additional binding on Condition.code that applies when
+  # Condition.category includes protective-factor (SDOHCC Condition, cond-5).
+  # VSAC "Protective Factors Findings", OID 2.16.840.1.113762.1.4.1247.311.
+  PROTECTIVE_FACTORS_VALUE_SET = "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1247.311".freeze
+
   CONDITION_CATEGORY = [
     {
       code: "sdoh-category-unspecified",
@@ -98,10 +114,6 @@ module ConditionDefinitionsHelper
     {
       code: "language-access",
       display: "Language Access"
-    },
-    {
-      code: "protective-factor",
-      display: "Protective Factor"
     }
   ]
 

--- a/app/helpers/conditions_helper.rb
+++ b/app/helpers/conditions_helper.rb
@@ -414,6 +414,15 @@ def description_options_condition
           ["Unemployment, unspecified", "Z56.0"],
           ["Encounter for counseling for socioeconomic factors", "Z71.88"],
       ],
+      # Condition.code for a protective factor is bound (extensible) to VSAC
+      # "Protective Factors Findings", OID 2.16.840.1.113762.1.4.1247.311, via the
+      # Additional Bindings on SDOHCC-Condition (cond-5). Source: the
+      # ProtectiveFactorsConditonCodes spreadsheet attached to CFRID-938,
+      # reconciled against the v20250702 expansion (36 concepts).
+      # Three entries below are not in that expansion and are carried under the
+      # extensible binding: 460821000124100, 611221000124108 (the IG's own
+      # Protective Factors narrative gives "Stably housed" as an example) and
+      # 671271000124101.
       "protective-factor" => [
           ["Spiritual strength (finding)", "105572002"],
           ["Food security (finding)", "1078229009"],

--- a/app/javascript/controllers/conditions_controller.js
+++ b/app/javascript/controllers/conditions_controller.js
@@ -4,11 +4,17 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = [
     "categorySelect",
+    "protectiveFactor",
     "icd10Code",
     "icd10Desc",
     "snomedCode",
     "snomedDesc"
   ];
+
+  // SDOHCC-Condition cond-5: when Condition.category includes protective-factor,
+  // Condition.code is drawn from the protective factor value set, whichever SDOH
+  // domain is also selected. So the checkbox, not the dropdown, keys the code list.
+  static PROTECTIVE_FACTOR = "protective-factor";
 
   connect() {
     this.descriptionOptions = JSON.parse(this.data.get("descriptionOptionsCondition"));
@@ -18,13 +24,13 @@ export default class extends Controller {
     const errorDiv = document.getElementById("conditions-errors");
     errorDiv.style.display = "none";
     errorDiv.textContent = "";
-    const hasCategory = this.categorySelectTarget.value.trim();
+    const hasCategory = this.categorySelectTarget.value.trim() || this.protectiveFactorSelected();
     const hasICD = this.icd10CodeTarget.value.trim() && this.icd10DescTarget.value.trim();
     const hasSNOMED = this.snomedCodeTarget.value.trim() && this.snomedDescTarget.value.trim();
     if( !hasCategory ){
       e.preventDefault();
       errorDiv.style.display = "block";
-      errorDiv.textContent = "Select a Category";
+      errorDiv.textContent = "Select a Category or mark this as a protective factor";
     }
     else if( !hasICD && !hasSNOMED ){
       e.preventDefault();
@@ -33,10 +39,28 @@ export default class extends Controller {
     }
   }
 
-  handleCategoryChange(e) {
-    const selectedCategory = e.target.value;
+  protectiveFactorSelected() {
+    return this.hasProtectiveFactorTarget && this.protectiveFactorTarget.checked;
+  }
+
+  handleCategoryChange() {
+    this.populateCodeOptions();
+  }
+
+  handleProtectiveFactorChange() {
+    // category[SDOHCC] is 0..*, so a protective factor may stand on its own.
+    this.categorySelectTarget.required = !this.protectiveFactorSelected();
+    this.populateCodeOptions();
+  }
+
+  populateCodeOptions() {
+    const selectedCategory = this.protectiveFactorSelected()
+      ? this.constructor.PROTECTIVE_FACTOR
+      : this.categorySelectTarget.value;
+
     if (!selectedCategory || selectedCategory === 'default') {
       this.disableOptions(true);
+      this.items = [];
       return;
     }
     this.disableOptions(false);
@@ -72,7 +96,7 @@ export default class extends Controller {
   handleCodeChange(e){
     const target = e.target;
     const code = target.value;
-    const match = this.items.find(i=>i[1] === code);
+    const match = (this.items || []).find(i=>i[1] === code);
 
     if(target === this.icd10CodeTarget){
       this.icd10DescTarget.value=match ? match[0]: "";
@@ -85,7 +109,7 @@ export default class extends Controller {
   handleDescriptionChange(e){
     const target = e.target;
     const display = target.value;
-    const match = this.items.find(i=>i[0] === display);
+    const match = (this.items || []).find(i=>i[0] === display);
 
     if(target === this.icd10DescTarget){
       this.icd10CodeTarget.value=match ? match[1]: "";

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -2,6 +2,10 @@
 class Condition
   include ModelHelper
 
+  SDOH_CATEGORY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+  US_CORE_CONDITION_CATEGORY_CODE_SYSTEM = "http://hl7.org/fhir/us/core/CodeSystem/condition-category".freeze
+  PROTECTIVE_FACTOR_CATEGORY = "protective-factor".freeze
+
   attr_reader :id, :clinical_status, :verification_status, :category, :type, :code, :subject_name, :subject_reference,
               :resolution_period, :onset_period, :asserter_name, :asserter_reference, :evidence_reference,
               :evidence_source, :fhir_resource
@@ -12,6 +16,7 @@ class Condition
     remove_client_instances(@fhir_resource)
     @clinical_status = get_code_from_complex(fhir_condition.clinicalStatus)
     @verification_status = get_code_from_complex(fhir_condition.verificationStatus)
+    @sdoh_category_codes = get_sdoh_category_codes(fhir_condition.category)
     @category = get_category_display(fhir_condition.category)
     @type = get_type(fhir_condition.category) # health-concern or problem-list-item
     @code = get_condition_code(fhir_condition.code)
@@ -33,24 +38,44 @@ class Condition
     end
   end
 
+  # category[SDOHCC] is 0..* on SDOHCC-Condition, so protective-factor sits
+  # alongside the SDOH domain rather than replacing it (cond-4).
+  def protective_factor?
+    @sdoh_category_codes.include?(PROTECTIVE_FACTOR_CATEGORY)
+  end
+
   private
 
   def get_code_from_complex(codeable_concept)
     codeable_concept&.coding&.first&.code&.downcase
   end
 
+  def sdoh_categories(category)
+    category
+      &.select { |c| c.coding&.first&.system == SDOH_CATEGORY_CODE_SYSTEM }
+      &.map { |c| c.coding&.first }
+      &.compact || []
+  end
+
+  def get_sdoh_category_codes(category)
+    sdoh_categories(category).map(&:code).compact
+  end
+
+  # A condition can carry several category[SDOHCC] repeats, so show all of the
+  # domains rather than only the first. protective-factor is excluded here and
+  # rendered as its own badge by conditions/_table.
   def get_category_display(category)
-    type =
-      category
-        &.find { |c| c.coding&.first&.system == "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes" }
-        &.coding
-        &.first
-    type&.display || type&.code&.gsub("-", " ")&.titleize
+    displays =
+      sdoh_categories(category)
+        .reject { |coding| coding.code == PROTECTIVE_FACTOR_CATEGORY }
+        .map { |coding| coding.display.presence || coding.code&.gsub("-", " ")&.titleize }
+        .compact
+    displays.join(", ").presence
   end
 
   def get_type(category)
     category
-      &.find { |c| c.coding&.first&.system == "http://hl7.org/fhir/us/core/CodeSystem/condition-category" }
+      &.find { |c| c.coding&.first&.system == US_CORE_CONDITION_CATEGORY_CODE_SYSTEM }
       &.coding
       &.first
       &.code

--- a/app/views/conditions/_form_modal.html.erb
+++ b/app/views/conditions/_form_modal.html.erb
@@ -15,6 +15,11 @@
             <%= f.label :category, "Category", class: "form-label" %>
             <%= f.select :category, options_for_select([["Select category", ""]] + ConditionDefinitionsHelper::CONDITION_CATEGORY.map { |type| [type[:display], type[:code]] }, ""), {}, { class: "form-select", id: "type-select", required: true , data: { conditions_target: "categorySelect" , action: "change->conditions#handleCategoryChange" } } %>
           </div>
+          <div class="mb-3 form-check">
+            <%= f.check_box :protective_factor, class: "form-check-input", id: "protective-factor", data: { conditions_target: "protectiveFactor", action: "change->conditions#handleProtectiveFactorChange" } %>
+            <%= f.label :protective_factor, "Protective factor", class: "form-check-label", for: "protective-factor" %>
+            <div class="form-text">Records this as a strength in addition to the SDOH category above. The code list switches to protective factor findings.</div>
+          </div>
           <div class="mb-3">
             <%= f.label :icd_code, "ICD-10", class: "form-label" %>
             <%= f.select :icd_code,options_for_select([["Select a ICD-10 Code", ""]]), {}, { id: "icd10_code", class: "form-select", disabled: "true", data: { conditions_target: "icd10Code" , action: "change->conditions#handleCodeChange" } } %>

--- a/app/views/conditions/_table.html.erb
+++ b/app/views/conditions/_table.html.erb
@@ -24,7 +24,12 @@
                 <%= render 'shared/fhir_resource_modal', resource: condition %>
               <% end %>
             </td>
-            <td><%= condition.category %></td>
+            <td>
+              <%= condition.category %>
+              <% if condition.protective_factor? %>
+                <span class="badge bg-success">Protective Factor</span>
+              <% end %>
+            </td>
             <td>
               <% if condition.evidence_reference.present? %>
                 <span class="btn btn-sm btn-link cursor-pointer" data-bs-toggle="modal" data-bs-target="#condition-evidence-modal-<%= condition.id %>">


### PR DESCRIPTION
### What shipped, and why it is wrong

`270f51b` added `protective-factor` to `CONDITION_CATEGORY`
(`app/helpers/condition_definitions_helper.rb`), the array that populates the Category
dropdown. `ConditionsController#category` built exactly two `CodeableConcept`s — the US Core
type and `params[:category]` — so selecting "Protective Factor" **replaced** the SDOH domain
code. A domain and `protective-factor` could never both be emitted. That mutually-exclusive
dropdown is in the deployed client today.

SDOHCC Condition says the opposite. `Condition.category` is sliced
`encounter-diagnosis 0..1 | problem-or-health-concern 0..* | screening-assessment 1..* |
SDOHCC 0..*`, and `protective-factor` is a member of
[SDOHCC ValueSet SDOH Category](https://build.fhir.org/ig/HL7/fhir-sdoh-clinicalcare/ValueSet-SDOHCC-ValueSetSDOHCategory.html)
— the *same* value set as `food-insecurity`, bound to the *same* repeating `category[SDOHCC]`
slice. The slice repeats, so the two coexist. Two tagged conformance statements on the profile
say so directly:

> **cond-4** — To represent a protective factor using this profile, `Condition.category` **SHALL**
> include the value `protective-factor`, in addition to adhering to all other constraints on the
> `Condition.category` element.
>
> **cond-5** — Consistent with the binding logic for other SDOH domains, when `Condition.category`
> includes `protective-factor`, the `Condition.code` **SHALL** be selected from the corresponding
> domain-specific value set (e.g., Protective Factor Diagnoses) found in Additional Bindings.

The IG's own example, `SDOHCC-ConditionProtectiveFactor`, carries `health-concern`, `sdoh` and
`protective-factor` simultaneously.

Verified against `HL7/fhir-sdoh-clinicalcare@6604b7a` (`origin/master`), profile
`input/fsh/profiles/SDOHCCCondition.fsh` and
`input/pagecontent/StructureDefinition-SDOHCC-Condition-intro.md`.

### The change

A **checkbox**, not a dropdown option and not a separate tab. Only a checkbox can express
"this active health concern *is also* a protective factor"; either alternative reintroduces the
one-or-the-other bug. The Category dropdown's other job — keying the code list — is taken over
by the checkbox when it is ticked, which is what cond-5 requires.

- `condition_definitions_helper.rb` — remove `protective-factor` from `CONDITION_CATEGORY`
  (23 domain entries remain). Add `CATEGORY_SCREENING_ASSESSMENT_CODE_SYSTEM`, `CATEGORY_SDOH`,
  `CATEGORY_PROTECTIVE_FACTOR` and `PROTECTIVE_FACTORS_VALUE_SET`, each citing the artefact.
- `conditions_controller.rb#category` — build the array so it always emits the US Core
  `health-concern`/`problem-list-item` code **and `sdoh`**, then append the SDOH domain when one
  is chosen and `protective-factor` when the box is ticked.
- `_form_modal.html.erb` — `protective_factor` checkbox after the Category group.
- `conditions_controller.js` — `protectiveFactor` target; `handleCategoryChange` and
  `handleProtectiveFactorChange` both route through a shared `populateCodeOptions()` that keys the
  code list off the checkbox when it is ticked. `disableOptions` semantics preserved.
- `condition.rb` — `get_category_display` used `&.find` and returned only the *first* SDOHCC
  `CodeableConcept`, so with two it silently hid one. Now selects/maps/joins every SDOHCC category;
  adds a `protective_factor?` predicate.
- `conditions/_table.html.erb` — distinct "Protective Factor" badge alongside the domain.
- `conditions_helper.rb` — source comment on the protective factor code list naming the value set
  OID and the CFRID-938 spreadsheet. **Code list otherwise unchanged** — see below.

### SDOH-Con-3 was failing for every Condition

The app never emitted a plain `sdoh` category, so **every** Condition it created violated
`SDOH-Con-3` ("At least one Condition.category SHALL be sdoh"), not only protective factors.
That is the same method, so it is fixed here. Ordinary health concerns are otherwise unchanged.

### Two corrections to the code list, both against expectation

The ticket brief called for deleting the ICD-10 `Z71.88` entry on the grounds that the protective
factor value set is SNOMED-only. It isn't. Expanding
`http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1247.311` (`tx.fhir.org`, version
`20250702`, 36 concepts) returns `Z71.88 "Encounter for counseling for socioeconomic factors"`
under `http://hl7.org/fhir/sid/icd-10-cm` as a genuine member. **`Z71.88` is kept.**

Reconciling the rest: all 35 SNOMED members of that expansion are present, none are missing and
none are retired. Three codes in the repo list are **not** in the `20250702` expansion —
`460821000124100` "Able to access healthcare services", `611221000124108` "Stably housed" and
`671271000124101` "Enrolled in health insurance coverage". The binding is *extensible* and the
IG's own Protective Factors narrative names "Stably housed" as an example protective factor, so
all three are kept and the discrepancy is recorded in a comment. Worth raising with Gravity that
the VSAC set does not contain a concept the IG text uses as its headline example.

Note also that the VSAC set's current title is **"Protective Factors Findings"**, not
"Protective Factor Diagnoses" as the IG narrative calls it.

### Behaviour with both categories

cond-2 says that when `Condition.category` carries more than one SDOH domain, `Condition.code`
**SHALL** be from at least one of the corresponding value sets. With `food-insecurity` +
`protective-factor` the code is drawn from the protective factor set, which satisfies both cond-2
and cond-5.

The Category select becomes optional while the checkbox is ticked, so a protective factor can be
recorded on its own — the shape the IG's own example uses. With the box clear it stays required,
as before.

### Verification

Local Referral Source client (`docker compose up -d --build` from this branch) against the shared
EHR FHIR server. Both resources below were **pulled back from the server**, not hand-written.

`Condition/558f41ec-67c6-4c07-9fa9-278da97af02d` — `food-insecurity`, checkbox clear:

```
category: condition-category#health-concern
          us-core-category#sdoh
          SDOHCC-CodeSystemTemporaryCodes#food-insecurity
code:     http://snomed.info/sct#733423003 "Food insecurity (finding)"
```

`Condition/e666cdf2-6632-4353-a489-534955ee2fc4` — `food-insecurity`, checkbox ticked:

```
category: condition-category#health-concern
          us-core-category#sdoh
          SDOHCC-CodeSystemTemporaryCodes#food-insecurity
          SDOHCC-CodeSystemTemporaryCodes#protective-factor
code:     http://snomed.info/sct#1137434003 "Has access to transportation (finding)"
```

The domain survives. The code list switched to the protective factor findings when the box was
ticked (SNOMED options went from the 8 food-insecurity codes to the 38 protective factor findings,
ICD-10 to `Z71.88` alone) and reverted on unticking.

Promoting the protective factor condition to a problem changed only the US Core slice —
`health-concern` → `problem-list-item`, with `sdoh`, `food-insecurity` and `protective-factor`
untouched — and the row renders under Active Problems with the domain and the badge intact.

**Validator** — `validator_cli.jar` 6.10.2, `-version 4.0.1`,
`-ig https://build.fhir.org/ig/HL7/fhir-sdoh-clinicalcare/package.tgz` (resolves as
`hl7.fhir.us.sdoh-clinicalcare#3.0.0`), `-ig hl7.fhir.us.core#7.0.0`, `-sct us`, profile asserted
with `-profile .../SDOHCC-Condition`:

| Resource | Errors |
|---|---|
| `e666cdf2…` (4 categories, protective factor) | **0** |
| `558f41ec…` (3 categories, ordinary) | **0** |
| `grover-food-insecurity` (2 categories, the pre-change shape) | **2** |

The third row is a Condition in the demo data with the shape the old code produced. It fails with
`SDOH-Con-3: 'At least one Condition.category SHALL be sdoh'` and
`Slice 'Condition.category:screening-assessment': a matching slice is required, but not found` —
which is precisely the defect this PR fixes, reproduced against the profile.

Remaining output is warnings only, all pre-existing and present on the unchanged resource too:
the base FHIR `condition-category` preferred-binding warning on every category coding, trailing
whitespace in `subject.display`/`asserter.display` (how the app composes names), and `dom-6`
narrative best practice.

`hl7.fhir.us.core#7.0.0` has to be passed explicitly. Without it the CI package resolves US Core
`3.1.1`, the 7.0.0 value sets bound to the `problem-or-health-concern` and `screening-assessment`
slices cannot be resolved, and every conformant instance fails the required-slice check. That is a
validation-environment artefact, not a property of the resources.

Based on `upstream/master`, not on any open PR branch.
