### PR TITLE
CFRID-973: Referral for Further Assessment (STU 3) — request an assessment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,18 @@
 class ApplicationController < ActionController::Base
+
+  # fhir_client walks a resource with FHIR::Model#each_element before it hands
+  # back the server's reply, and a raw Hash cannot be walked. Any resource that
+  # still carried one turned every server rejection into
+  # "undefined method `each_element' for Hash" instead of the OperationOutcome
+  # the server actually sent. The builders in these controllers describe
+  # resources as hashes, so each one becomes the FHIR type it belongs to on the
+  # way onto the resource. FHIR::Model.new already coerces the nested hashes.
+  def as_fhir(fhir_class, attributes)
+    return if attributes.blank?
+    return attributes.map { |attribute| fhir_class.new(attribute) } if attributes.is_a?(Array)
+
+    fhir_class.new(attributes)
+  end
   protect_from_forgery with: :null_session
   include ApplicationHelper
 

--- a/app/controllers/conditions_controller.rb
+++ b/app/controllers/conditions_controller.rb
@@ -4,14 +4,14 @@ class ConditionsController < ApplicationController
   def create
     begin
       condition = FHIR::Condition.new
-      condition.meta = meta
-      condition.clinicalStatus = clinical_status
-      condition.verificationStatus = verification_status
-      condition.category = category
-      condition.code = code
-      condition.subject = subject
-      condition.onsetPeriod = onset_period
-      condition.asserter = asserter
+      condition.meta = as_fhir(FHIR::Meta, meta)
+      condition.clinicalStatus = as_fhir(FHIR::CodeableConcept, clinical_status)
+      condition.verificationStatus = as_fhir(FHIR::CodeableConcept, verification_status)
+      condition.category = as_fhir(FHIR::CodeableConcept, category)
+      condition.code = as_fhir(FHIR::CodeableConcept, code)
+      condition.subject = as_fhir(FHIR::Reference, subject)
+      condition.onsetPeriod = as_fhir(FHIR::Period, onset_period)
+      condition.asserter = as_fhir(FHIR::Reference, asserter)
 
       get_client.create(condition)
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -104,7 +104,7 @@ class DashboardController < ApplicationController
   end
 
   def set_tasks
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT)
     if success
       @active_referrals = result["active"] || []
       @completed_referrals = result["completed"] || []
@@ -114,7 +114,7 @@ class DashboardController < ApplicationController
       flash[:warning] = result
     end
 
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_PATIENT)
     if success
       @active_patient_tasks = result["active"] || []
       @completed_patient_tasks = result["completed"] || []

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -95,7 +95,7 @@ class GoalsController < ApplicationController
   ### Create a new goal ###
   def meta
     {
-      "profile": ["http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Goal"],
+      "profile": [FhirProfiles::GOAL],
     }
   end
 
@@ -116,7 +116,7 @@ class GoalsController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": params[:category],
             "display": params[:category]&.split("-")&.join(" ")&.titleize,
           },

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,8 +1,6 @@
 class OrganizationsController < ApplicationController
   before_action :require_client
 
-  CAPACITY_EXTENSION_URL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
-
   # The four concepts bound to SDOHCC-ValueSetCapacityStatus, mapped to the
   # statuses the front end understands. These are the only capacity codes in
   # SDOHCC-CodeSystemTemporaryCodes: "at-capacity" and "no-capacity-has-waitlist"
@@ -28,7 +26,7 @@ class OrganizationsController < ApplicationController
     Rails.logger.info("[CHECK_CAPACITY] Found #{services.size} HealthcareService(s): #{services.map(&:id)}")
 
     # Prefer the first service that actually carries a capacity extension
-    extension = services.filter_map { |s| s.extension&.find { |e| e.url == CAPACITY_EXTENSION_URL } }.first
+    extension = services.filter_map { |s| s.extension&.find { |e| e.url == FhirProfiles::CAPACITY_STATUS_EXTENSION } }.first
     # SDOHCC-ExtensionHealthcareServiceCapacityStatus is a complex extension:
     # capacityStatus is 1..1 and Extension.value[x] is prohibited (0..0).
     capacity_status_extension = extension&.extension&.find { |e| e.url == "capacityStatus" }

--- a/app/controllers/patient_tasks_controller.rb
+++ b/app/controllers/patient_tasks_controller.rb
@@ -90,7 +90,7 @@ class PatientTasksController < ApplicationController
   def patient_task_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient",
+        FhirProfiles::TASK_FOR_PATIENT,
       ],
     }
   end

--- a/app/controllers/personal_characteristics_controller.rb
+++ b/app/controllers/personal_characteristics_controller.rb
@@ -7,13 +7,13 @@ class PersonalCharacteristicsController < ApplicationController
   def create
     begin
       obs = FHIR::Observation.new
-      obs.meta = obs_meta
+      obs.meta = as_fhir(FHIR::Meta, obs_meta)
       obs.status = "final"
-      obs.category = obs_category
-      obs.local_method = obs_method
-      obs.subject = obs_subject
+      obs.category = as_fhir(FHIR::CodeableConcept, obs_category)
+      obs.local_method = as_fhir(FHIR::CodeableConcept, obs_method)
+      obs.subject = as_fhir(FHIR::Reference, obs_subject)
       obs.effectiveDateTime = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
-      obs.performer = [obs_subject] if params[:reported_method] == "self-reported"
+      obs.performer = [as_fhir(FHIR::Reference, obs_subject)] if params[:reported_method] == "self-reported"
       obs.derivedFrom = [FHIR::Reference.new(reference: params[:derived_from])] if params[:derived_from].present?
       set_fields_base_on_type(obs)
 
@@ -65,8 +65,8 @@ class PersonalCharacteristicsController < ApplicationController
 
   #### Personal Pronoun type ####
   def add_personal_pronoun_attr(obs)
-    obs.code = personal_pronoun_code
-    obs.valueCodeableConcept = personal_pronoun_valueCodeableConcept
+    obs.code = as_fhir(FHIR::CodeableConcept, personal_pronoun_code)
+    obs.valueCodeableConcept = as_fhir(FHIR::CodeableConcept, personal_pronoun_valueCodeableConcept)
   end
 
   def personal_pronoun_code
@@ -95,8 +95,8 @@ class PersonalCharacteristicsController < ApplicationController
 
   #### Ethnicity type ####
   def add_ethnicity_attr(obs)
-    obs.code = ethnicity_code
-    obs.component = ethnicity_component
+    obs.code = as_fhir(FHIR::CodeableConcept, ethnicity_code)
+    obs.component = as_fhir(FHIR::Observation::Component, ethnicity_component)
   end
 
   def ethnicity_code

--- a/app/controllers/personal_characteristics_controller.rb
+++ b/app/controllers/personal_characteristics_controller.rb
@@ -148,7 +148,7 @@ class PersonalCharacteristicsController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": "personal-characteristic"
           }
         ]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -78,7 +78,7 @@ class TasksController < ApplicationController
   def poll_referral_tasks
     saved_tasks = Rails.cache.read(tasks_key) || []
     Rails.cache.delete(tasks_key)
-    success, result = fetch_tasks("http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement")
+    success, result = fetch_tasks(FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT)
     if success
       @active_referrals = result["active"] || []
       @completed_referrals = result["completed"] || []
@@ -114,7 +114,7 @@ class TasksController < ApplicationController
   def task_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement",
+        FhirProfiles::TASK_FOR_REFERRAL_MANAGEMENT,
       ],
     }
   end
@@ -151,7 +151,7 @@ class TasksController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": "make-contact",  # Example: Replace with the correct code from SDOHCC Task for Patient
             "display": "Make Contact",
           },
@@ -163,7 +163,7 @@ class TasksController < ApplicationController
   def service_req_meta
     {
       "profile": [
-        "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ServiceRequest",
+        FhirProfiles::SERVICE_REQUEST,
       ],
     }
   end
@@ -182,7 +182,7 @@ class TasksController < ApplicationController
       {
         "coding": [
           {
-            "system": "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes",
+            "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
             "code": params[:category],
             "display": params[:category]&.titleize,
           },

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -210,18 +210,33 @@ class TasksController < ApplicationController
     }
   end
 
+  # The Condition the referral is being made about, when one was chosen.
+  #
+  # There is not always one - a patient with no problems recorded has an empty
+  # Problem list - and "Condition/" is not a reference. A FHIR server rejects
+  # any resource that copies it (HAPI-0508 "Invalid resource reference ... Does
+  # not contain resource ID"), so the referral target could not complete the
+  # referral: its Procedure copies ServiceRequest.reasonReference.
   def service_req_reason_reference
+    condition_id = params[:condition_ids].presence
+    return if condition_id.blank?
+
     [
       {
-        "reference": "Condition/#{params[:condition_ids]}",
+        "reference": "Condition/#{condition_id}",
       },
     ]
   end
 
+  # Same for the Consent: the picker offers "Select Consent", and a referral
+  # sent without one must not carry "Consent/".
   def service_req_supporting_info
+    consent_id = params[:consent].presence
+    return if consent_id.blank?
+
     [
       {
-        "reference": "Consent/#{params[:consent]}",
+        "reference": "Consent/#{consent_id}",
       },
     ]
   end

--- a/app/helpers/condition_definitions_helper.rb
+++ b/app/helpers/condition_definitions_helper.rb
@@ -1,7 +1,7 @@
 # Helper constants valueset for Condition resource (health concern/ problem)
 module ConditionDefinitionsHelper
-  CONDITION_PROFILE = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition".freeze
-  CATEGORY_SDOH_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+  CONDITION_PROFILE = FhirProfiles::CONDITION
+  CATEGORY_SDOH_CODE_SYSTEM = FhirProfiles::TEMPORARY_CODE_SYSTEM
   CONDITION_CATEGORY_US_CORE_CODE_SYSTEM = "http://hl7.org/fhir/us/core/CodeSystem/condition-category".freeze
   SNOMED_CODE_SYSTEM = "http://snomed.info/sct".freeze
   ICD_10_CODE_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm".freeze

--- a/app/helpers/personal_characteristics_definitions_helper.rb
+++ b/app/helpers/personal_characteristics_definitions_helper.rb
@@ -1,6 +1,6 @@
 module PersonalCharacteristicsDefinitionsHelper
   # Code Systems
-  REPORTED_METHODS_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+  REPORTED_METHODS_SYSTEM = FhirProfiles::TEMPORARY_CODE_SYSTEM
 
   PERSONAL_PRONOUNS_OTHER = "OTH".freeze
   SEX_GENDER_OTHER = "LA32969-0".freeze
@@ -23,12 +23,12 @@ module PersonalCharacteristicsDefinitionsHelper
   }.freeze
 
   PERSONAL_CHARACTERISTICS_PROFILES = {
-    race: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRaceOMB",
-    ethnicity: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationEthnicityOMB",
-    gender_identity: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationGenderIdentity",
-    recorded_sex_gender: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRecordedSexGender",
-    sexual_orientation: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationSexualOrientation",
-    personal_pronouns: "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationPersonalPronouns"
+    race: FhirProfiles::OBSERVATION_RACE_OMB,
+    ethnicity: FhirProfiles::OBSERVATION_ETHNICITY_OMB,
+    gender_identity: FhirProfiles::OBSERVATION_GENDER_IDENTITY,
+    recorded_sex_gender: FhirProfiles::OBSERVATION_RECORDED_SEX_GENDER,
+    sexual_orientation: FhirProfiles::OBSERVATION_SEXUAL_ORIENTATION,
+    personal_pronouns: FhirProfiles::OBSERVATION_PERSONAL_PRONOUNS
   }.freeze
 
   PERSONAL_PRONOUNS = [

--- a/app/helpers/practitioner_helper.rb
+++ b/app/helpers/practitioner_helper.rb
@@ -26,10 +26,15 @@ module PractitionerHelper
     client = get_client
     begin
       response = client.read(FHIR::Practitioner, practitioner_id)
-      if response.response[:code] == 200
-        practitioner = Practitioner.new(response.resource)
+      fhir_practitioner = read_practitioner_resource(response.resource)
+      if response.response[:code] == 200 && fhir_practitioner
+        practitioner = Practitioner.new(fhir_practitioner)
         save_current_practitioner(practitioner)
         [true, practitioner]
+      elsif response.response[:code] == 200
+        Rails.logger.error("Practitioner/#{practitioner_id} came back as #{response.resource.class} rather than a Practitioner.")
+
+        [false, "Failed to fetch practitioner. The server answered with #{response.resource.class} rather than a Practitioner."]
       else
         Rails.logger.error("Failed to fetch patient's personal characteristics. Status: #{response.response[:code]} - #{response.response[:body]}")
 
@@ -42,6 +47,17 @@ module PractitionerHelper
       # rescue Rack::Timeout::RequestTimeoutException => e
       #   [false, "Request timeout. Please try again later. #{e.message}"]
     end
+  end
+
+  # A read can come back as a Bundle rather than the resource asked for -
+  # TaskIoEntry has handled that since it was written, and this had not, so
+  # every practitioner 500d on "undefined method name for FHIR::Bundle" and took
+  # the dashboard down with it. Unwrap a Bundle the same way, and then
+  # check the type rather than assuming it: a Bundle with no entries, or an
+  # OperationOutcome, is not a Practitioner either.
+  def read_practitioner_resource(resource)
+    resource = resource.entry&.first&.resource if resource.is_a?(FHIR::Bundle)
+    resource if resource.is_a?(FHIR::Practitioner)
   end
 
   def fetch_and_cache_practitioners

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -97,9 +97,6 @@ module TasksHelper
       "housing-instability" => [
         ["Assessment of health and social care needs", "710824005"],
         ["Assessment for housing insecurity", "1148447008"],
-        # 225340009 is not a member of the housing value set above. It is left
-        # in place because referrals already exist that use it.
-        ["Housing assessment", "225340009"],
         ["Referral to housing service", "710911006"],
       ],
       "transportation-insecurity" => [

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,6 +1,18 @@
 module TasksHelper
   include SessionHelper
 
+  # Badge colours for SDOHCC-ValueSetEnrollmentStatus. Enrolled reads as done,
+  # a waitlist as something still outstanding, not enrolled as neither.
+  ENROLLMENT_STATUS_BADGE_CLASSES = {
+    "enrolled" => "bg-success",
+    "not-enrolled" => "bg-secondary",
+    "not-enrolled-on-waitlist" => "bg-warning text-dark",
+  }.freeze
+
+  def enrollment_status_badge_class(code)
+    ENROLLMENT_STATUS_BADGE_CLASSES.fetch(code, "bg-light text-dark border")
+  end
+
   def save_tasks(tasks)
     Rails.cache.write(tasks_key, tasks, expires_in: 30.minutes)
   end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -67,10 +67,24 @@ module TasksHelper
     ]
   end
 
+  # What can be requested, by SDOH domain. SDOHCC-ServiceRequest binds
+  # ServiceRequest.code to US Core Procedure Codes (required) and adds an
+  # extensible additional binding per ServiceRequest.category: for these three
+  # domains those are the VSAC value sets Food Insecurity Service Requests
+  # (http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1247.11),
+  # Housing Instability Service Requests (...1.4.1247.45) and Transportation
+  # Insecurity Service Requests (...1.4.1247.28), all version 20240604.
+  #
+  # rffa.html asks for both a general and a domain-specific assessment request,
+  # because ServiceRequest.code is the only thing that separates "assess this
+  # person for food insecurity" from "give this person food". The general code
+  # 710824005 is a member of all three value sets; the domain-specific
+  # assessment codes are members of their own.
   def request_options
     {
       "food-insecurity" => [
         ["Assessment of health and social care needs", "710824005"],
+        ["Assessment for food insecurity", "1002224003"],
         ["Assessment of nutritional status", "1759002"],
         ["Counseling about nutrition", "441041000124100"],
         ["Meals on wheels provision education", "385767005"],
@@ -81,6 +95,10 @@ module TasksHelper
         ["Referral to social worker", "308440001"],
       ],
       "housing-instability" => [
+        ["Assessment of health and social care needs", "710824005"],
+        ["Assessment for housing insecurity", "1148447008"],
+        # 225340009 is not a member of the housing value set above. It is left
+        # in place because referrals already exist that use it.
         ["Housing assessment", "225340009"],
         ["Referral to housing service", "710911006"],
       ],

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -42,7 +42,7 @@ class Condition
   def get_category_display(category)
     type =
       category
-        &.find { |c| c.coding&.first&.system == "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes" }
+        &.find { |c| c.coding&.first&.system == FhirProfiles::TEMPORARY_CODE_SYSTEM }
         &.coding
         &.first
     type&.display || type&.code&.gsub("-", " ")&.titleize

--- a/app/models/fhir_profiles.rb
+++ b/app/models/fhir_profiles.rb
@@ -53,6 +53,13 @@ module FhirProfiles
   RESULTING_ACTIVITY_CODE = "resulting-activity".freeze
   RESULTING_ACTIVITY_DISPLAY = "Resulting Activity".freeze
 
+  # SDOHCC-CodeSystemTemporaryCodes concept that SDOHCC-ObservationProgramEnrollmentStatus
+  # fixes category[enrollment] to. Task.output:AdditionalContent carries
+  # assessments, screening responses, goals, conditions and questionnaire
+  # responses as well as enrollment status, so the category is what identifies
+  # an enrollment status Observation among them.
+  PROGRAM_ENROLLMENT_CATEGORY_CODE = "program-enrollment".freeze
+
   # --- US Core extensions (hl7.fhir.us.core) ---
 
   # US Core Race Extension

--- a/app/models/fhir_profiles.rb
+++ b/app/models/fhir_profiles.rb
@@ -1,0 +1,64 @@
+# Canonical URLs for the FHIR artifacts this client reads and writes.
+#
+# Every profile, extension and temporary-code-system URL used anywhere in the
+# application is declared here so that a spec change is a one-line edit and so
+# that no two call sites can disagree about a canonical URL. Nothing outside
+# this module should carry one as a string literal.
+#
+# SDOH artifacts are from HL7 FHIR Implementation Guide "Social Determinants of
+# Health Clinical Care" (hl7.fhir.us.sdoh-clinicalcare), STU 3 continuous build.
+module FhirProfiles
+  # --- SDOH Clinical Care profiles ---
+
+  # SDOHCC Task For Referral Management
+  TASK_FOR_REFERRAL_MANAGEMENT = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForReferralManagement".freeze
+  # SDOHCC Task For Patient
+  TASK_FOR_PATIENT = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-TaskForPatient".freeze
+  # SDOHCC ServiceRequest
+  SERVICE_REQUEST = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ServiceRequest".freeze
+  # SDOHCC Procedure
+  PROCEDURE = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Procedure".freeze
+  # SDOHCC Goal
+  GOAL = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Goal".freeze
+  # SDOHCC Condition
+  CONDITION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition".freeze
+
+  # SDOHCC Observation Race OMB
+  OBSERVATION_RACE_OMB = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRaceOMB".freeze
+  # SDOHCC Observation Ethnicity OMB
+  OBSERVATION_ETHNICITY_OMB = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationEthnicityOMB".freeze
+  # SDOHCC Observation Gender Identity
+  OBSERVATION_GENDER_IDENTITY = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationGenderIdentity".freeze
+  # SDOHCC Observation Recorded Sex Gender
+  OBSERVATION_RECORDED_SEX_GENDER = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRecordedSexGender".freeze
+  # SDOHCC Observation Sexual Orientation
+  OBSERVATION_SEXUAL_ORIENTATION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationSexualOrientation".freeze
+  # SDOHCC Observation Personal Pronouns
+  OBSERVATION_PERSONAL_PRONOUNS = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationPersonalPronouns".freeze
+
+  # --- SDOH Clinical Care extensions ---
+
+  # SDOHCC Extension Healthcare Service Capacity Status
+  CAPACITY_STATUS_EXTENSION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ExtensionHealthcareServiceCapacityStatus".freeze
+
+  # --- SDOH Clinical Care code system ---
+
+  # SDOHCC CodeSystem Temporary Codes
+  TEMPORARY_CODE_SYSTEM = "http://hl7.org/fhir/us/sdoh-clinicalcare/CodeSystem/SDOHCC-CodeSystemTemporaryCodes".freeze
+
+  # The two SDOHCC-CodeSystemTemporaryCodes concepts that discriminate the
+  # Task.input and Task.output slices in SDOHCC-TaskForReferralManagement.
+  ADDITIONAL_CONTENT_CODE = "additional-content".freeze
+  ADDITIONAL_CONTENT_DISPLAY = "Additional Content".freeze
+  RESULTING_ACTIVITY_CODE = "resulting-activity".freeze
+  RESULTING_ACTIVITY_DISPLAY = "Resulting Activity".freeze
+
+  # --- US Core extensions (hl7.fhir.us.core) ---
+
+  # US Core Race Extension
+  US_CORE_RACE_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race".freeze
+  # US Core Ethnicity Extension
+  US_CORE_ETHNICITY_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity".freeze
+  # US Core Birth Sex Extension
+  US_CORE_BIRTHSEX_EXTENSION = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex".freeze
+end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,7 +1,7 @@
 class Observation
   include ModelHelper
 
-  attr_reader :id, :code, :category, :value, :effective_date_time, :fhir_resource
+  attr_reader :id, :code, :category, :value, :effective_date_time, :note, :fhir_resource
 
   def initialize(fhir_observation)
     @id = fhir_observation.id
@@ -9,11 +9,36 @@ class Observation
     remove_client_instances(@fhir_resource)
     @code = get_code_string(fhir_observation.code)
     @category = get_category_display(fhir_observation.category)
+    @category_codes = get_category_codes(fhir_observation.category)
     @value = get_code_string(fhir_observation.valueCodeableConcept) if fhir_observation.valueCodeableConcept.present?
+    @value_coding = fhir_observation.valueCodeableConcept&.coding&.first
     @effective_date_time = fhir_observation.effectiveDateTime
+    @note = fhir_observation.note&.map { |note| note&.text }&.compact&.join(" ").presence
+  end
+
+  # An SDOHCC Observation Program Enrollment Status: the profile fixes
+  # category[enrollment] to program-enrollment, so that is what marks one out
+  # from any other Observation a Task.output entry may reference.
+  def program_enrollment?
+    @category_codes.include?(FhirProfiles::PROGRAM_ENROLLMENT_CATEGORY_CODE)
+  end
+
+  # Observation.value[x] as a code from SDOHCC-ValueSetEnrollmentStatus:
+  # enrolled, not-enrolled or not-enrolled-on-waitlist. The code, not the
+  # display, is what a badge colour is chosen from.
+  def enrollment_status_code
+    @value_coding&.code
+  end
+
+  def enrollment_status_display
+    @value_coding&.display.presence || @value_coding&.code&.tr("-", " ")&.titleize
   end
 
   private
+
+  def get_category_codes(category)
+    Array(category).flat_map { |c| Array(c&.coding) }.map { |coding| coding&.code }.compact
+  end
 
   def get_code_string(code)
     c = code&.coding&.first

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -43,19 +43,19 @@ class Patient
 
     fhir_patient_extension_arr&.each do |ext|
       case ext&.url
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+      when FhirProfiles::US_CORE_RACE_EXTENSION
         ext.extension&.each do |race_ext|
           if race_ext&.url == 'ombCategory' && race_ext&.valueCoding&.display
             characteristics[:race] << race_ext.valueCoding.display
           end
         end
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+      when FhirProfiles::US_CORE_ETHNICITY_EXTENSION
         ext.extension&.each do |ethnicity_ext|
           if ethnicity_ext&.url == 'ombCategory' && ethnicity_ext&.valueCoding&.display
             characteristics[:ethnicity] << ethnicity_ext.valueCoding.display
           end
         end
-      when 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+      when FhirProfiles::US_CORE_BIRTHSEX_EXTENSION
         characteristics[:birthsex] = ext.valueCode
       end
     end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -21,10 +21,14 @@ class Procedure
     display || codeable_concept&.coding&.map(&:code)&.join(", ")&.gsub("-", " ")&.titleize
   end
 
+  # Procedure.reasonReference is 0..*, and a referral made with no problem
+  # recorded produces a Procedure with none. Reading .reference off nil raised,
+  # TaskIoEntry's rescue turned that into an unresolved output, and the Outcomes
+  # cell fell back to a bare "Resulting Activity" with nothing behind it.
   def read_reference(reference, fhir_client)
-    id = reference.reference_id
+    id = reference&.reference_id
 
-    return nil if fhir_client.nil?
+    return nil if id.blank? || fhir_client.nil?
 
     condition = fhir_client.read(FHIR::Condition, id).resource
     # sometimes for some reason read returns FHIR::Bundle

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task
   include ModelHelper
 
-  attr_reader :id, :status, :focus, :owner_reference, :owner_name, :outcome, :outcome_type, :fhir_resource, :code
+  attr_reader :id, :status, :focus, :owner_reference, :owner_name, :outputs, :inputs, :fhir_resource, :code
 
   def initialize(fhir_task, fhir_client: nil)
     @id = fhir_task.id
@@ -11,11 +11,45 @@ class Task
     @focus = get_focus(fhir_task.focus, fhir_client)
     @owner_reference = fhir_task.owner&.reference
     @owner_name = fhir_task.owner&.display
-    @outcome = get_outcome(fhir_task.output&.first, fhir_client)
+    @outputs = build_io_entries(fhir_task.output, fhir_client)
+    # Inputs are parsed but their references are deliberately not resolved: no
+    # view renders Task.input yet, and resolving one would cost a server read
+    # per entry on every dashboard refresh. Pass the client here when one does.
+    @inputs = build_io_entries(fhir_task.input, nil)
     @code = get_coding(fhir_task.code&.coding&.first)
   end
 
+  # Task.output entries under the resulting-activity code: what was done.
+  def performed_activity_outputs
+    outputs.select(&:performed_activity?)
+  end
+
+  # Task.output entries under the additional-content code: enrollment status,
+  # assessments, goals, conditions and the like.
+  def additional_content_outputs
+    outputs.select(&:additional_content?)
+  end
+
+  # Task.input entries under the additional-content code.
+  def additional_content_inputs
+    inputs.select(&:additional_content?)
+  end
+
+  # The first resulting-activity output. Kept so callers written against the
+  # single-outcome API keep working while they move to #outputs.
+  def outcome
+    performed_activity_outputs.first&.then { |entry| entry.resource || entry.value }
+  end
+
+  def outcome_type
+    performed_activity_outputs.first&.display_type
+  end
+
   private
+
+  def build_io_entries(entries, fhir_client)
+    Array(entries).filter_map { |entry| TaskIoEntry.build(entry, fhir_client) }
+  end
 
   def get_focus(focus, fhir_client)
     return if focus.nil?
@@ -25,46 +59,6 @@ class Task
     # sometimes for some reason read returns FHIR::Bundle
     fhir_focus = fhir_focus&.entry&.first&.resource if fhir_focus.is_a?(FHIR::Bundle)
     ServiceRequest.new(fhir_focus, fhir_client: fhir_client) if fhir_focus
-  end
-
-  def get_outcome(outcome, fhir_client)
-    return if outcome.nil?
-
-    # if output is a reference, try to resolve it
-    if outcome.valueReference.present?
-      type = outcome.valueReference&.reference.split("/").first
-      id = outcome.valueReference&.reference.split("/").last
-
-      Rails.logger.info("outcome type:  #{type} id: #{id}")
-
-      case type
-      when "Procedure"
-        @outcome_type = "Procedure"
-        fhir_outcome = fhir_client.read(FHIR::Procedure, id).resource
-        Procedure.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      when "QuestionnaireResponse"
-        @outcome_type = "QuestionnaireResponse"
-        fhir_outcome = fhir_client.read(FHIR::QuestionnaireResponse, id).resource
-        QuestionnaireResponse.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      when "DocumentReference"
-        @outcome_type = "DocumentReference"
-        fhir_outcome = fhir_client.read(FHIR::DocumentReference, id).resource
-        DocumentReference.new(fhir_outcome, fhir_client: fhir_client) if fhir_outcome
-      else
-        nil
-      end
-
-    # codes and markdown just returned as strings
-    elsif outcome.valueCodeableConcept.present?
-      outcome.valueCodeableConcept.coding&.first&.code&.titleize
-      @outcome_type = outcome.type&.coding&.first&.code&.titleize
-    elsif outcome.valueMarkdown.present?
-      outcome.valueMarkdown
-      @outcome_type = "markdown"
-    end
-
-
-
   end
 
   def get_coding(coding)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -35,6 +35,21 @@ class Task
     inputs.select(&:additional_content?)
   end
 
+  # The Enrollment Status Observation this referral was closed with, if there
+  # is one.
+  #
+  # enrollment.html, referral-triggered workflow: "To close the loop on the
+  # referral, the CBO updates the Task, pointing to the Enrollment Status
+  # Observation in Task.output." It arrives in the AdditionalContent slice,
+  # which is shared with assessments, goals and conditions, so the Observation's
+  # own category is what identifies it.
+  def enrollment_status
+    additional_content_outputs
+      .map(&:resource)
+      .compact
+      .find { |resource| resource.is_a?(Observation) && resource.program_enrollment? }
+  end
+
   # The first resulting-activity output. Kept so callers written against the
   # single-outcome API keep working while they move to #outputs.
   def outcome

--- a/app/models/task_io_entry.rb
+++ b/app/models/task_io_entry.rb
@@ -1,0 +1,205 @@
+# One entry of Task.input or Task.output.
+#
+# SDOHCC-TaskForReferralManagement slices Task.output on both Task.output.type
+# and the type of Task.output.value[x], and slices Task.input on
+# Task.input.type. Both slicings are open and every slice is 0..*, so one
+# completed referral can carry a Procedure reference, a procedure code and any
+# number of additional-content references at the same time. Reading only the
+# first entry, or assuming a reference points at a Procedure, loses data.
+#
+# This wraps a single entry: which slice it belongs to, the referenced resource
+# or literal value it carries, and enough type information for a view to render
+# it without going back to the server.
+class TaskIoEntry
+  attr_reader :slice, :type_code, :type_display, :value_kind, :reference,
+              :resource_type, :resource_id, :resource, :value
+
+  def self.build(fhir_entry, fhir_client = nil)
+    return if fhir_entry.nil?
+
+    new(fhir_entry, fhir_client)
+  end
+
+  # Splits "Procedure/123", an absolute URL or a versioned reference into its
+  # resource type and id. Contained ("#p1") and urn: references have no type and
+  # yield [nil, nil], as does anything that does not look like a resource type.
+  def self.parse_reference(reference)
+    return [nil, nil] if reference.blank?
+
+    path = reference.to_s.split("?").first.to_s
+    return [nil, nil] if path.start_with?("#", "urn:")
+
+    segments = path.split("/").reject(&:blank?)
+    history_at = segments.index("_history")
+    segments = segments[0...history_at] if history_at
+    type = segments[-2]
+    id = segments[-1]
+    return [nil, nil] unless type.to_s.match?(/\A[A-Z][A-Za-z]+\z/)
+
+    [type, id]
+  end
+
+  def initialize(fhir_entry, fhir_client = nil)
+    @type_code = read_type_code(fhir_entry.type)
+    @type_display = read_type_display(fhir_entry.type)
+    @value_kind = read_value_kind(fhir_entry)
+    @reference = fhir_entry.valueReference&.reference
+    @resource_type, @resource_id = self.class.parse_reference(@reference)
+    @slice = read_slice
+    @value = read_value(fhir_entry)
+    @resource = resolve(fhir_client)
+  end
+
+  # PerformedActivityReference and PerformedActivityCode both sit under the
+  # resulting-activity code; either one describes what was actually done.
+  def performed_activity?
+    slice == :performed_activity_reference || slice == :performed_activity_code
+  end
+
+  def additional_content?
+    slice == :additional_content
+  end
+
+  def reference?
+    value_kind == :reference
+  end
+
+  def resolved?
+    resource.present?
+  end
+
+  # What a view labels this entry with: the referenced resource's type where
+  # there is one, otherwise the slice's own display.
+  def display_type
+    case value_kind
+    when :reference then resource_type.presence || type_display
+    when :markdown then "markdown"
+    else type_display
+    end
+  end
+
+  def id
+    resource&.id || resource_id
+  end
+
+  private
+
+  # The temporary-codes coding is the one the profile discriminates on; fall
+  # back to the first coding so an off-spec entry still describes itself.
+  def read_type_code(type)
+    codings = Array(type&.coding)
+    coding = codings.find { |c| c&.system == FhirProfiles::TEMPORARY_CODE_SYSTEM } || codings.first
+    coding&.code
+  end
+
+  def read_type_display(type)
+    return if type_code.blank?
+
+    type_code.titleize
+  end
+
+  def read_value_kind(fhir_entry)
+    return :reference if fhir_entry.valueReference&.reference.present?
+    return :codeable_concept if fhir_entry.valueCodeableConcept.present?
+    return :markdown if fhir_entry.valueMarkdown.present?
+    return :string if fhir_entry.valueString.present?
+
+    :other
+  end
+
+  def read_slice
+    case type_code
+    when FhirProfiles::RESULTING_ACTIVITY_CODE
+      case value_kind
+      when :reference then :performed_activity_reference
+      when :codeable_concept then :performed_activity_code
+      else :unknown
+      end
+    when FhirProfiles::ADDITIONAL_CONTENT_CODE
+      :additional_content
+    else
+      :unknown
+    end
+  end
+
+  # The value, not the name of the slice it arrived in.
+  def read_value(fhir_entry)
+    case value_kind
+    when :codeable_concept
+      coding = fhir_entry.valueCodeableConcept&.coding&.first
+      coding&.display.presence || coding&.code&.titleize
+    when :markdown
+      fhir_entry.valueMarkdown
+    when :string
+      fhir_entry.valueString
+    end
+  end
+
+  # Resolved by the resource type in the reference itself. Assuming Procedure
+  # fetched an Observation as a Procedure and silently dropped it.
+  def resolve(fhir_client)
+    return if fhir_client.nil? || resource_type.blank? || resource_id.blank?
+
+    fhir_resource = read_fhir_resource(fhir_client)
+    return if fhir_resource.nil?
+
+    wrap(fhir_resource, fhir_client)
+  rescue => e
+    Rails.logger.warn("Unable to resolve Task #{type_code} entry #{reference}: #{e.message}")
+    nil
+  end
+
+  def read_fhir_resource(fhir_client)
+    fhir_class = fhir_class_for(resource_type)
+    if fhir_class.nil?
+      Rails.logger.info("Task #{type_code} entry references unknown resource type #{resource_type}")
+      return
+    end
+
+    Rails.logger.info("Task #{type_code} entry: reading #{resource_type}/#{resource_id}")
+    fhir_resource = fhir_client.read(fhir_class, resource_id).resource
+    # sometimes for some reason read returns FHIR::Bundle
+    fhir_resource = fhir_resource&.entry&.first&.resource if fhir_resource.is_a?(FHIR::Bundle)
+    fhir_resource if fhir_resource.is_a?(fhir_class)
+  end
+
+  def fhir_class_for(type)
+    return unless FHIR.const_defined?(type, false)
+
+    fhir_class = FHIR.const_get(type, false)
+    fhir_class if fhir_class.is_a?(Class) && fhir_class <= FHIR::Model
+  end
+
+  # A type with no model of its own is still shown, as raw FHIR, rather than
+  # being dropped.
+  def wrap(fhir_resource, fhir_client)
+    case resource_type
+    when "Procedure" then Procedure.new(fhir_resource, fhir_client: fhir_client)
+    when "Observation" then Observation.new(fhir_resource)
+    when "Condition" then Condition.new(fhir_resource, fhir_client: fhir_client)
+    when "Goal" then Goal.new(fhir_resource, fhir_client: fhir_client)
+    when "QuestionnaireResponse" then QuestionnaireResponse.new(fhir_resource, fhir_client: fhir_client)
+    when "DocumentReference" then DocumentReference.new(fhir_resource, fhir_client: fhir_client)
+    else GenericResource.new(fhir_resource)
+    end
+  end
+
+  # A referenced resource this client has no model for: enough for a view to
+  # link to it and for shared/_fhir_resource_modal to render it.
+  class GenericResource
+    include ModelHelper
+
+    attr_reader :id, :resource_type, :fhir_resource
+
+    def initialize(fhir_resource)
+      @fhir_resource = fhir_resource
+      remove_client_instances(@fhir_resource)
+      @id = fhir_resource.id
+      @resource_type = fhir_resource.resourceType
+    end
+
+    def resourceType
+      resource_type
+    end
+  end
+end

--- a/app/models/task_io_entry.rb
+++ b/app/models/task_io_entry.rb
@@ -82,7 +82,45 @@ class TaskIoEntry
     resource&.id || resource_id
   end
 
+  # What the referenced resource actually says, for a table cell that would
+  # otherwise read "Additional Content (QuestionnaireResponse)". A completed
+  # assessment comes back as several resources at once, and the reader needs to
+  # tell a food insecurity Condition from a PRAPARE response without opening
+  # each modal in turn.
+  def resource_label
+    fhir_resource = resource&.fhir_resource
+    return if fhir_resource.nil?
+
+    text =
+      case fhir_resource
+      when FHIR::Goal then codeable_display(fhir_resource.description)
+      when FHIR::CarePlan then fhir_resource.title.presence || codeable_display(fhir_resource.category&.first)
+      when FHIR::QuestionnaireResponse then questionnaire_display(fhir_resource)
+      else codeable_display(fhir_resource.code)
+      end
+
+    text.presence
+  end
+
   private
+
+  def codeable_display(codeable_concept)
+    return if codeable_concept.blank?
+
+    coding = Array(codeable_concept.coding).first
+    codeable_concept.text.presence || coding&.display.presence || coding&.code
+  end
+
+  # QuestionnaireResponse.questionnaire is a canonical URL. Resolving it would
+  # be one more read per outcome on a table that already reads every referenced
+  # resource, so the last segment is spaced out instead:
+  # ".../SDOHCC-QuestionnairePRAPARE" reads as "Questionnaire PRAPARE".
+  def questionnaire_display(fhir_resource)
+    segment = fhir_resource.questionnaire.to_s.split("|").first.to_s.split("/").reject(&:blank?).last
+    return if segment.blank?
+
+    segment.sub(/\ASDOHCC-/, "").gsub(/([a-z])([A-Z])/, '\1 \2')
+  end
 
   # The temporary-codes coding is the one the profile discriminates on; fall
   # back to the first coding so an off-spec entry still describes itself.

--- a/app/views/action_steps/_observation_modal.html.erb
+++ b/app/views/action_steps/_observation_modal.html.erb
@@ -1,0 +1,46 @@
+<%# Enrollment Status Observation behind the badge in the Outcomes column. %>
+<%# Separate from action_steps/_procedure_modal, whose card header is hardcoded %>
+<%# to Procedure/<id> and whose fields (performed date, addresses) do not apply. %>
+<div id="enrollment-observation-modal-<%= resource.id %>" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Enrollment Status</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="card">
+          <div class="card-header">
+            <h6 class="card-title">Observation/<%= resource.id %></h6>
+          </div>
+          <div class="card-body">
+            <div class="label-value">
+              <span class="fw-semibold">Program:</span>
+              <span class="small-text"><%= resource.code || "--" %></span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Category:</span>
+              <span class="small-text"><%= resource.category || "--" %></span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Enrollment Status:</span>
+              <span class="badge <%= enrollment_status_badge_class(resource.enrollment_status_code) %>">
+                <%= resource.enrollment_status_display || "--" %>
+              </span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Enrollment Date:</span>
+              <span class="small-text"><%= resource.effective_date_time || "--" %></span>
+            </div>
+            <% if resource.note.present? %>
+              <div class="label-value">
+                <span class="fw-semibold">Note:</span>
+                <span class="small-text"><%= resource.note %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/action_steps/_procedure_modal.html.erb
+++ b/app/views/action_steps/_procedure_modal.html.erb
@@ -27,10 +27,14 @@
               <span class="fw-semibold">Performed Date:</span>
               <span class="small-text"><%= resource.performed_date.to_date %></span>
             </div>
-            <div class="label-value">
-              <span class="fw-semibold">Addresses:</span>
-              <span class="small-text">Condition/<%= resource.problem&.id %></span>
-            </div>
+            <%# reasonReference is 0..*, so a Procedure can have no problem to %>
+            <%# address; the row read "Condition/" with nothing after it. %>
+            <% if resource.problem.present? %>
+              <div class="label-value">
+                <span class="fw-semibold">Addresses:</span>
+                <span class="small-text">Condition/<%= resource.problem.id %></span>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -121,7 +121,11 @@
                         <%= render "action_steps/procedure_modal", resource: output.resource %>
                       <% end %>
                     <% else %>
-                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <%# Name the resource, not the slice it arrived in: a %>
+                      <%# completed assessment returns several at once and %>
+                      <%# "Additional Content (QuestionnaireResponse)" three %>
+                      <%# times over says nothing about what came back. %>
+                      <%= link_to "#{output.resource_label.presence || output.display_type} (#{output.display_type})", "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
                       <% content_for :modals do %>
                         <%= render "shared/fhir_resource_modal", resource: output.resource %>
                       <% end %>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -116,7 +116,7 @@
                         <%= render "shared/string_modal", { id: "#{referral.id}-#{index}", resource: output.value } %>
                       <% end %>
                     <% elsif output.resource_type == "Procedure" %>
-                      <%= link_to output.display_type, "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <%= link_to "#{output.resource_label.presence || output.display_type} (#{output.display_type})", "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
                       <% content_for :modals do %>
                         <%= render "action_steps/procedure_modal", resource: output.resource %>
                       <% end %>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -90,9 +90,24 @@
 
             <% if type == "completed" %>
               <td>
-                <% if referral&.outputs.present? %>
-                  <% referral.outputs.each_with_index do |output, index| %>
-                    <% if index.positive? %>, <% end %>
+                <%# The enrollment status the CBO closed the referral with leads %>
+                <%# the cell: it is the outcome the referrer is looking for, and %>
+                <%# it gets its own modal rather than the Procedure's. %>
+                <% enrollment = referral&.enrollment_status %>
+                <% if enrollment.present? %>
+                  <%= link_to "#enrollment-observation-modal-#{enrollment.id}", data: { bs_toggle: "modal" }, class: "text-decoration-none" do %>
+                    <span class="badge <%= enrollment_status_badge_class(enrollment.enrollment_status_code) %>">
+                      <%= enrollment.enrollment_status_display %>
+                    </span>
+                  <% end %>
+                  <% content_for :modals do %>
+                    <%= render "action_steps/observation_modal", resource: enrollment %>
+                  <% end %>
+                <% end %>
+                <% other_outputs = Array(referral&.outputs).reject { |output| enrollment.present? && output.resource == enrollment } %>
+                <% if other_outputs.present? %>
+                  <% other_outputs.each_with_index do |output, index| %>
+                    <% if index.positive? || enrollment.present? %>, <% end %>
                     <% if output.resource.blank? && output.value.blank? %>
                       <span class="small-text"><%= output.display_type %></span>
                     <% elsif output.resource.blank? %>
@@ -112,7 +127,7 @@
                       <% end %>
                     <% end %>
                   <% end %>
-                <% else %>
+                <% elsif enrollment.blank? %>
                   --
                 <% end %>
               </td>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -90,10 +90,27 @@
 
             <% if type == "completed" %>
               <td>
-                <% if referral&.outcome&.id.present? %>
-                  <%= link_to referral.outcome_type, "#referral-procedure-modal-#{referral.outcome&.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "action_steps/procedure_modal", resource: referral.outcome %>
+                <% if referral&.outputs.present? %>
+                  <% referral.outputs.each_with_index do |output, index| %>
+                    <% if index.positive? %>, <% end %>
+                    <% if output.resource.blank? && output.value.blank? %>
+                      <span class="small-text"><%= output.display_type %></span>
+                    <% elsif output.resource.blank? %>
+                      <%= link_to output.display_type, "#string-modal-#{referral.id}-#{index}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/string_modal", { id: "#{referral.id}-#{index}", resource: output.value } %>
+                      <% end %>
+                    <% elsif output.resource_type == "Procedure" %>
+                      <%= link_to output.display_type, "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "action_steps/procedure_modal", resource: output.resource %>
+                      <% end %>
+                    <% else %>
+                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/fhir_resource_modal", resource: output.resource %>
+                      <% end %>
+                    <% end %>
                   <% end %>
                 <% else %>
                   --

--- a/app/views/patient_tasks/_table.html.erb
+++ b/app/views/patient_tasks/_table.html.erb
@@ -91,15 +91,22 @@
 
             <% if type == "completed" %>
               <td>
-                <% if task.outcome.is_a? String %>
-                  <%= link_to task.outcome_type, "#string-modal-#{task.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "shared/string_modal", {id: task.id, resource: task.outcome} %>
-                  <% end %>
-                <% elsif task.outcome&.id.present? %>
-                  <%= link_to task.outcome_type, "#fhir-resource-modal-#{task.outcome&.id}", data: { bs_toggle: "modal" } %>
-                  <% content_for :modals do %>
-                    <%= render "shared/fhir_resource_modal", resource: task.outcome %>
+                <% if task.outputs.present? %>
+                  <% task.outputs.each_with_index do |output, index| %>
+                    <% if index.positive? %>, <% end %>
+                    <% if output.resource.present? %>
+                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/fhir_resource_modal", resource: output.resource %>
+                      <% end %>
+                    <% elsif output.value.present? %>
+                      <%= link_to output.display_type, "#string-modal-#{task.id}-#{index}", data: { bs_toggle: "modal" } %>
+                      <% content_for :modals do %>
+                        <%= render "shared/string_modal", { id: "#{task.id}-#{index}", resource: output.value } %>
+                      <% end %>
+                    <% else %>
+                      <span class="small-text"><%= output.display_type %></span>
+                    <% end %>
                   <% end %>
                 <% else %>
                   --


### PR DESCRIPTION
Draft: based on `feature/enrollment-status`, so the diff includes CFRID-966's and CFRID-968's
commits until those merge. Rebase onto `master` and mark ready once CFRID-968 is in.

`rffa.md` asks for both a general and a domain-specific assessment request, because
`ServiceRequest.code` is the only thing separating "assess this person for food insecurity" from
"give this person food". Food insecurity offered only the general code; housing offered neither.

The codes come from the VSAC value sets `SDOHCC-ServiceRequest` binds `ServiceRequest.code` to per
`ServiceRequest.category` (version 20240604), not from the narrative:

- **`1002224003` "Assessment for food insecurity"** under food-insecurity. The guide's example
  phrase "Food insecurity risk assessment (procedure)" is not a concept — it is not in SNOMED CT
  and not in VSAC `2.16.840.1.113762.1.4.1247.11` "Food Insecurity Service Requests", whose food
  assessment concept is this one. Worth raising with the Gravity editors.
- **`710824005` "Assessment of health and social care needs"** under housing-instability. It is a
  member of the food, housing and transportation value sets alike, so the general assessment
  request is conformant in every domain this client supports.
- **`1148447008` "Assessment for housing insecurity"** under housing-instability, the domain-specific
  housing equivalent. VSAC `…1.4.1247.45` "Housing Instability Service Requests" contains it, and
  four ServiceRequests on the shared EHR server already use it.

The three-domain `category_options` list is unchanged: the food and housing assessment codes hang
off the domains that already exist, and nothing in this use case needs a new domain.

**Second commit — `225340009` "Housing assessment" is no longer offered.** It is not invalid:
it is a member of `us-core-procedure-code`, the required binding on `ServiceRequest.code`, and an
existing ServiceRequest using it validates with 0 errors. But it is outside the **extensible**
additional binding for the housing-instability category, so the validator warns on every referral
created with it —

```
ServiceRequest.code: None of the codings provided are in the value set
'Housing Instability Service Requests'
(http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1247.45|20240604)
specified in an additional binding which applies because ServiceRequest.category ...
```

— and `1148447008` above is in that value set, means the same thing and validates clean. There is no
reason for this client to keep offering the one that warns. This does not touch referrals that
already use the code: `request_options` only supplies the create form's list and the display written
into `ServiceRequest.code`, so the six on the connectathon server render from their own
`code.coding.display` as before, and the Coordination Platform still recognises the code so they
still read as assessments. Restoring the option is one line if the team wants it back for testing.

**Third commit — `reasonReference` and `supportingInfo` were written even when nothing was
chosen**, producing `"Condition/"` and `"Consent/"`. Neither is a reference. A FHIR server rejects
any resource that copies one (`HAPI-0508 … Does not contain resource ID`), which is what the
referral target hits when its Procedure copies `ServiceRequest.reasonReference` on completion — the
referral could not be closed at all. The Problem list is empty for a patient with no problem-list
Conditions, so this is the normal path rather than an edge case; both elements are 0..*, and
leaving them out says what is true.

**Fourth commit — outcomes are named rather than labelled by the slice they arrived in.** A
completed referral read `Additional Content (QuestionnaireResponse)`, which does not say which
instrument came back.

**Final commit — a Procedure with no reason reference stopped resolving.** Dropping the unusable
`"Condition/"` left `Procedure.reasonReference` absent, and this client's `Procedure` model called
`.reference` on `read_reference(fhir_procedure.reasonReference&.first)` with no nil guard. The
`NoMethodError` was swallowed by `TaskIoEntry#resolve`'s rescue, so the outcome counted as
unresolved and the cell fell back to a bare "Resulting Activity" with nothing behind it. Only
completions made after that fix were affected, because older Procedures still carried a
reasonReference. `reasonReference` is 0..*, so absent is a normal value and is now treated as one.
The Procedure link is named like the rest of the cell — "Assessment for housing insecurity
(Procedure)" rather than "Resulting Activity".

**Prompt item 10 (multi-output display) is already done** by CFRID-966 and CFRID-968 and needed no
change here. Verified rather than rebuilt: the completed referral renders `Procedure,
QuestionnaireResponse, Observation, Condition`, each with its own modal.

## Evidence

Screenshot: "Assessment for food insecurity" selectable in the referral form, and the completed
referral showing all four returned outcomes.

Created `ServiceRequest/7854e86d-8f4f-46cb-bdce-bb2d0863c2f0`
(`code = http://snomed.info/sct|1002224003 "Assessment for food insecurity"`, `intent = order`,
category `food-insecurity`) and `Task/b23123ff-0f47-4546-874f-fa2637999c17`; carried through the
Coordination Platform to the CBO and back with four outputs.

**Follow-on commits — every practitioner 500d, so the dashboard was down.** `client.read` can answer
with a Bundle rather than the resource asked for. `TaskIoEntry` has handled that since it was
written; `fetch_practitioner` had not, so `Practitioner.new` was handed a `FHIR::Bundle`, raised on
`.name`, and took the entire dashboard down — for every practitioner, not an occasional one. It now
unwraps a Bundle the same way `TaskIoEntry` does and checks the type rather than assuming it, so a
Bundle with no entries or an OperationOutcome is reported as "the server answered with X rather
than a Practitioner" instead of raising.

Shown in the browser: connect, pick Dr Jan Water — the practitioner that failed every time before —
and the patient list renders; a referral for BAXTER COLIN V. was then created through the Add
Referral form (`ServiceRequest/d2007c71-eb11-4e7e-8c3a-4590a5cbd2b9`, code `1002224003`, with no
`reasonReference`).

The same commit set also turns the Condition and personal-characteristic builders' hashes into FHIR
objects through one `as_fhir` helper, for the masking reason above; resources built by passing a
hash to `FHIR::ServiceRequest.new` and friends were never affected, because the constructor coerces,
which is why the referral and task builders are untouched.
