### PR TITLE
CFRID-975: Content-rich referral — Task.input additional content (STU 3)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,18 @@
 class ApplicationController < ActionController::Base
+
+  # fhir_client walks a resource with FHIR::Model#each_element before it hands
+  # back the server's reply, and a raw Hash cannot be walked. Any resource that
+  # still carried one turned every server rejection into
+  # "undefined method `each_element' for Hash" instead of the OperationOutcome
+  # the server actually sent. The builders in these controllers describe
+  # resources as hashes, so each one becomes the FHIR type it belongs to on the
+  # way onto the resource. FHIR::Model.new already coerces the nested hashes.
+  def as_fhir(fhir_class, attributes)
+    return if attributes.blank?
+    return attributes.map { |attribute| fhir_class.new(attribute) } if attributes.is_a?(Array)
+
+    fhir_class.new(attributes)
+  end
   protect_from_forgery with: :null_session
   include ApplicationHelper
 

--- a/app/controllers/conditions_controller.rb
+++ b/app/controllers/conditions_controller.rb
@@ -4,14 +4,14 @@ class ConditionsController < ApplicationController
   def create
     begin
       condition = FHIR::Condition.new
-      condition.meta = meta
-      condition.clinicalStatus = clinical_status
-      condition.verificationStatus = verification_status
-      condition.category = category
-      condition.code = code
-      condition.subject = subject
-      condition.onsetPeriod = onset_period
-      condition.asserter = asserter
+      condition.meta = as_fhir(FHIR::Meta, meta)
+      condition.clinicalStatus = as_fhir(FHIR::CodeableConcept, clinical_status)
+      condition.verificationStatus = as_fhir(FHIR::CodeableConcept, verification_status)
+      condition.category = as_fhir(FHIR::CodeableConcept, category)
+      condition.code = as_fhir(FHIR::CodeableConcept, code)
+      condition.subject = as_fhir(FHIR::Reference, subject)
+      condition.onsetPeriod = as_fhir(FHIR::Period, onset_period)
+      condition.asserter = as_fhir(FHIR::Reference, asserter)
 
       get_client.create(condition)
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -14,6 +14,7 @@ class DashboardController < ApplicationController
       set_personal_characteristics
       set_conditions
       set_social_risk_assessments
+      set_sdoh_observations
       set_goals
       set_tasks
       set_service_requests
@@ -89,6 +90,17 @@ class DashboardController < ApplicationController
       @social_risk_assessments = result
     else
       Rails.logger.info("Failed to set social risk assessments: #{result}")
+      flash[:warning] = result
+    end
+  end
+
+  def set_sdoh_observations
+    success, result = fetch_sdoh_observations
+    if success
+      @sdoh_assessments = result["assessment"] || []
+      @sdoh_screening_responses = result["screening-response"] || []
+    else
+      Rails.logger.info("Failed to set SDOH observations: #{result}")
       flash[:warning] = result
     end
   end

--- a/app/controllers/personal_characteristics_controller.rb
+++ b/app/controllers/personal_characteristics_controller.rb
@@ -7,13 +7,13 @@ class PersonalCharacteristicsController < ApplicationController
   def create
     begin
       obs = FHIR::Observation.new
-      obs.meta = obs_meta
+      obs.meta = as_fhir(FHIR::Meta, obs_meta)
       obs.status = "final"
-      obs.category = obs_category
-      obs.local_method = obs_method
-      obs.subject = obs_subject
+      obs.category = as_fhir(FHIR::CodeableConcept, obs_category)
+      obs.local_method = as_fhir(FHIR::CodeableConcept, obs_method)
+      obs.subject = as_fhir(FHIR::Reference, obs_subject)
       obs.effectiveDateTime = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
-      obs.performer = [obs_subject] if params[:reported_method] == "self-reported"
+      obs.performer = [as_fhir(FHIR::Reference, obs_subject)] if params[:reported_method] == "self-reported"
       obs.derivedFrom = [FHIR::Reference.new(reference: params[:derived_from])] if params[:derived_from].present?
       set_fields_base_on_type(obs)
 
@@ -65,8 +65,8 @@ class PersonalCharacteristicsController < ApplicationController
 
   #### Personal Pronoun type ####
   def add_personal_pronoun_attr(obs)
-    obs.code = personal_pronoun_code
-    obs.valueCodeableConcept = personal_pronoun_valueCodeableConcept
+    obs.code = as_fhir(FHIR::CodeableConcept, personal_pronoun_code)
+    obs.valueCodeableConcept = as_fhir(FHIR::CodeableConcept, personal_pronoun_valueCodeableConcept)
   end
 
   def personal_pronoun_code
@@ -95,8 +95,8 @@ class PersonalCharacteristicsController < ApplicationController
 
   #### Ethnicity type ####
   def add_ethnicity_attr(obs)
-    obs.code = ethnicity_code
-    obs.component = ethnicity_component
+    obs.code = as_fhir(FHIR::CodeableConcept, ethnicity_code)
+    obs.component = as_fhir(FHIR::Observation::Component, ethnicity_component)
   end
 
   def ethnicity_code

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -210,18 +210,33 @@ class TasksController < ApplicationController
     }
   end
 
+  # The Condition the referral is being made about, when one was chosen.
+  #
+  # There is not always one - a patient with no problems recorded has an empty
+  # Problem list - and "Condition/" is not a reference. A FHIR server rejects
+  # any resource that copies it (HAPI-0508 "Invalid resource reference ... Does
+  # not contain resource ID"), so the referral target could not complete the
+  # referral: its Procedure copies ServiceRequest.reasonReference.
   def service_req_reason_reference
+    condition_id = params[:condition_ids].presence
+    return if condition_id.blank?
+
     [
       {
-        "reference": "Condition/#{params[:condition_ids]}",
+        "reference": "Condition/#{condition_id}",
       },
     ]
   end
 
+  # Same for the Consent: the picker offers "Select Consent", and a referral
+  # sent without one must not carry "Consent/".
   def service_req_supporting_info
+    consent_id = params[:consent].presence
+    return if consent_id.blank?
+
     [
       {
-        "reference": "Consent/#{params[:consent]}",
+        "reference": "Consent/#{consent_id}",
       },
     ]
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,39 @@
 class TasksController < ApplicationController
   before_action :require_client
 
+  # Task.input:AdditionalContent.type, the coding the profile discriminates the
+  # slice on.
+  #
+  # referral_workflow.html says only that "the provider may attach additional
+  # content relevant for the care of the individual through the SDOHCC Task
+  # resource" - it never names the slice or the code. The binding comes from
+  # SDOHCC-TaskForReferralManagement:
+  #   input[AdditionalContent].type = $SDOHCC-CodeSystemTemporaryCodes#additional-content
+  ADDITIONAL_CONTENT_TYPE = {
+    "coding": [
+      {
+        "system": FhirProfiles::TEMPORARY_CODE_SYSTEM,
+        "code": FhirProfiles::ADDITIONAL_CONTENT_CODE,
+        "display": FhirProfiles::ADDITIONAL_CONTENT_DISPLAY,
+      },
+    ],
+  }.freeze
+
+  # input[AdditionalContent].value[x] is Reference(Resource) with no
+  # targetProfile, so any resource is legal and a bare id is not enough to build
+  # a reference from. The picker submits "<ResourceType>/<id>" and both halves
+  # are used; only the types this client actually offers are accepted, so no
+  # unvalidated parameter is ever interpolated into a reference.
+  ADDITIONAL_CONTENT_RESOURCE_TYPES = %w[
+    Condition
+    Consent
+    DocumentReference
+    Goal
+    Observation
+    QuestionnaireResponse
+    ServiceRequest
+  ].freeze
+
   def create
     begin
       # Service Request
@@ -29,6 +62,7 @@ class TasksController < ApplicationController
         authoredOn: Time.now.utc.strftime("%Y-%m-%dT%H:%M:%S.%3NZ"),
         requester: task_requester,
         owner: task_owner,
+        input: task_input,
       )
       get_client.create(task)
 
@@ -158,6 +192,40 @@ class TasksController < ApplicationController
         ],
       }
     end
+
+  ### Task.input ###
+
+  # The resources the provider chose to send with the referral, as
+  # Task.input:AdditionalContent entries.
+  #
+  # Returns nil rather than [] when nothing was selected so that the element is
+  # omitted from the Task instead of being emitted empty: input is 0..*, and an
+  # empty array is not what "no additional content" looks like on the wire.
+  def task_input
+    entries = Array(params[:additional_content_ids]).filter_map do |value|
+      reference = additional_content_reference(value)
+      next if reference.blank?
+
+      {
+        "type": ADDITIONAL_CONTENT_TYPE,
+        "valueReference": { "reference": reference },
+      }
+    end
+
+    entries.presence
+  end
+
+  # "Condition/abc" and nothing else. The type has to be one this client offers
+  # and the id has to look like a FHIR id ([A-Za-z0-9-.]{1,64}), so a crafted
+  # parameter cannot become part of a reference. Parsing is TaskIoEntry's, which
+  # is what reads these references back.
+  def additional_content_reference(value)
+    resource_type, id = TaskIoEntry.parse_reference(value)
+    return unless ADDITIONAL_CONTENT_RESOURCE_TYPES.include?(resource_type)
+    return unless id.to_s.match?(/\A[A-Za-z0-9\-.]{1,64}\z/)
+
+    "#{resource_type}/#{id}"
+  end
 
   ### Service Request Attributes ###
   def service_req_meta

--- a/app/helpers/practitioner_helper.rb
+++ b/app/helpers/practitioner_helper.rb
@@ -26,10 +26,15 @@ module PractitionerHelper
     client = get_client
     begin
       response = client.read(FHIR::Practitioner, practitioner_id)
-      if response.response[:code] == 200
-        practitioner = Practitioner.new(response.resource)
+      fhir_practitioner = read_practitioner_resource(response.resource)
+      if response.response[:code] == 200 && fhir_practitioner
+        practitioner = Practitioner.new(fhir_practitioner)
         save_current_practitioner(practitioner)
         [true, practitioner]
+      elsif response.response[:code] == 200
+        Rails.logger.error("Practitioner/#{practitioner_id} came back as #{response.resource.class} rather than a Practitioner.")
+
+        [false, "Failed to fetch practitioner. The server answered with #{response.resource.class} rather than a Practitioner."]
       else
         Rails.logger.error("Failed to fetch patient's personal characteristics. Status: #{response.response[:code]} - #{response.response[:body]}")
 
@@ -42,6 +47,17 @@ module PractitionerHelper
       # rescue Rack::Timeout::RequestTimeoutException => e
       #   [false, "Request timeout. Please try again later. #{e.message}"]
     end
+  end
+
+  # A read can come back as a Bundle rather than the resource asked for -
+  # TaskIoEntry has handled that since it was written, and this had not, so
+  # every practitioner 500d on "undefined method name for FHIR::Bundle" and took
+  # the dashboard down with it. Unwrap a Bundle the same way, and then
+  # check the type rather than assuming it: a Bundle with no entries, or an
+  # OperationOutcome, is not a Practitioner either.
+  def read_practitioner_resource(resource)
+    resource = resource.entry&.first&.resource if resource.is_a?(FHIR::Bundle)
+    resource if resource.is_a?(FHIR::Practitioner)
   end
 
   def fetch_and_cache_practitioners

--- a/app/helpers/social_risks_helper.rb
+++ b/app/helpers/social_risks_helper.rb
@@ -24,4 +24,47 @@ module SocialRisksHelper
     Rails.logger.error(e.full_message)
     [false, "Failed to fetch social risk assessments. #{e.message}"]
   end
+
+  # The Observations that carry the patient's social risk: the derived
+  # assessments and the individual screening answers behind them.
+  #
+  # SDOHCC-TaskForReferralManagement, "Content-Rich Referral": "The requester
+  # may want to include in the request the completed assessment(s) that led to
+  # the action of submitting a referral. The requester will reference those
+  # assessments (QuestionnaireResponse, SDOHCC Observation Screening Response,
+  # etc.) in Task.input." These are the Observations that sentence names.
+  #
+  # Searched by profile rather than by category: an SDOHCC-ObservationAssessment
+  # carries category sdoh on some domains and social-history on others, so
+  # category=sdoh silently drops a quarter of them. Grouped by profile too - a
+  # derived finding and a single questionnaire answer are not the same kind of
+  # thing to attach to a referral, and there are far more of the latter.
+  def fetch_sdoh_observations
+    client = get_client
+    response = client.search(
+      FHIR::Observation,
+      search: {
+        parameters: {
+          subject: "Patient/#{patient_id}",
+          _profile: [FhirProfiles::OBSERVATION_ASSESSMENT, FhirProfiles::OBSERVATION_SCREENING_RESPONSE].join(","),
+          _sort: "-date",
+        },
+      },
+    )
+
+    if response.response[:code] == 200 && response.resource.is_a?(FHIR::Bundle)
+      entries = response.resource.entry&.map(&:resource) || []
+      grouped = entries.map { |entry| Observation.new(entry) }.group_by do |observation|
+        profiles = Array(observation.fhir_resource&.meta&.profile)
+        profiles.include?(FhirProfiles::OBSERVATION_ASSESSMENT) ? "assessment" : "screening-response"
+      end
+      [true, grouped]
+    else
+      Rails.logger.error("Failed to fetch SDOH observations. Status: #{response.response[:code]} - #{response.response[:body]}")
+      [false, "Failed to fetch SDOH observations."]
+    end
+  rescue StandardError => e
+    Rails.logger.error(e.full_message)
+    [false, "Failed to fetch SDOH observations. #{e.message}"]
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -128,4 +128,54 @@ module TasksHelper
     end
     map
   end
+  # The resources the provider can attach to a referral as
+  # Task.input:AdditionalContent, grouped by resource type for
+  # grouped_options_for_select.
+  #
+  # The IG's worked example is a diagnosis plus the results that support it, so
+  # the groups are the clinical context this client already has loaded for the
+  # patient: no group costs an extra server read.
+  #
+  # value[x] is Reference(Resource) with no targetProfile, so the option value
+  # is "<ResourceType>/<id>": a bare id cannot be turned into a reference.
+  def additional_content_options
+    {
+      "Problems & Health Concerns" => Array(@active_problems) + Array(@active_health_concerns),
+      "Goals" => Array(@active_goals),
+      "Assessments" => Array(@social_risk_assessments),
+      "Observations" => Array(@personal_characteristics),
+      "Service Requests" => Array(@service_requests),
+      "Consents" => Array(consents),
+    }.filter_map do |group, records|
+      options = Array(records).filter_map { |record| additional_content_option(record) }
+      [group, options] if options.present?
+    end
+  end
+
+  # One option: what the provider reads, and the reference the controller builds
+  # from it. The resource type comes off the FHIR resource itself rather than
+  # from the group it was listed under, so a mislabelled group cannot produce a
+  # reference that points at the wrong endpoint.
+  def additional_content_option(record)
+    return if record.nil? || record.id.blank?
+
+    resource_type = record.fhir_resource&.resourceType
+    return if resource_type.blank?
+
+    [additional_content_label(record), "#{resource_type}/#{record.id}"]
+  end
+
+  def additional_content_label(record)
+    text =
+      case record
+      when Condition then record.code
+      when Goal then record.description
+      when QuestionnaireResponse then [record.display_questionnaire, record.display_date].reject(&:blank?).join(" - ")
+      when PersonalCharacteristic then [record.type, record.value].reject(&:blank?).join(": ")
+      when ServiceRequest then record.description
+      when Consent then record.code
+      end
+
+    text.presence || "#{record.fhir_resource&.resourceType}/#{record.id}"
+  end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -142,8 +142,9 @@ module TasksHelper
     {
       "Problems & Health Concerns" => Array(@active_problems) + Array(@active_health_concerns),
       "Goals" => Array(@active_goals),
-      "Assessments" => Array(@social_risk_assessments),
-      "Observations" => Array(@personal_characteristics),
+      "Completed Questionnaires" => Array(@social_risk_assessments),
+      "Assessment Findings" => Array(@sdoh_assessments),
+      "Screening Responses" => Array(@sdoh_screening_responses),
       "Service Requests" => Array(@service_requests),
       "Consents" => Array(consents),
     }.filter_map do |group, records|
@@ -171,7 +172,7 @@ module TasksHelper
       when Condition then record.code
       when Goal then record.description
       when QuestionnaireResponse then [record.display_questionnaire, record.display_date].reject(&:blank?).join(" - ")
-      when PersonalCharacteristic then [record.type, record.value].reject(&:blank?).join(": ")
+      when Observation then [record.code, record.value].reject(&:blank?).join(": ")
       when ServiceRequest then record.description
       when Consent then record.code
       end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -97,9 +97,6 @@ module TasksHelper
       "housing-instability" => [
         ["Assessment of health and social care needs", "710824005"],
         ["Assessment for housing insecurity", "1148447008"],
-        # 225340009 is not a member of the housing value set above. It is left
-        # in place because referrals already exist that use it.
-        ["Housing assessment", "225340009"],
         ["Referral to housing service", "710911006"],
       ],
       "transportation-insecurity" => [

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,6 +1,18 @@
 module TasksHelper
   include SessionHelper
 
+  # Badge colours for SDOHCC-ValueSetEnrollmentStatus. Enrolled reads as done,
+  # a waitlist as something still outstanding, not enrolled as neither.
+  ENROLLMENT_STATUS_BADGE_CLASSES = {
+    "enrolled" => "bg-success",
+    "not-enrolled" => "bg-secondary",
+    "not-enrolled-on-waitlist" => "bg-warning text-dark",
+  }.freeze
+
+  def enrollment_status_badge_class(code)
+    ENROLLMENT_STATUS_BADGE_CLASSES.fetch(code, "bg-light text-dark border")
+  end
+
   def save_tasks(tasks)
     Rails.cache.write(tasks_key, tasks, expires_in: 30.minutes)
   end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -67,10 +67,24 @@ module TasksHelper
     ]
   end
 
+  # What can be requested, by SDOH domain. SDOHCC-ServiceRequest binds
+  # ServiceRequest.code to US Core Procedure Codes (required) and adds an
+  # extensible additional binding per ServiceRequest.category: for these three
+  # domains those are the VSAC value sets Food Insecurity Service Requests
+  # (http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1247.11),
+  # Housing Instability Service Requests (...1.4.1247.45) and Transportation
+  # Insecurity Service Requests (...1.4.1247.28), all version 20240604.
+  #
+  # rffa.html asks for both a general and a domain-specific assessment request,
+  # because ServiceRequest.code is the only thing that separates "assess this
+  # person for food insecurity" from "give this person food". The general code
+  # 710824005 is a member of all three value sets; the domain-specific
+  # assessment codes are members of their own.
   def request_options
     {
       "food-insecurity" => [
         ["Assessment of health and social care needs", "710824005"],
+        ["Assessment for food insecurity", "1002224003"],
         ["Assessment of nutritional status", "1759002"],
         ["Counseling about nutrition", "441041000124100"],
         ["Meals on wheels provision education", "385767005"],
@@ -81,6 +95,10 @@ module TasksHelper
         ["Referral to social worker", "308440001"],
       ],
       "housing-instability" => [
+        ["Assessment of health and social care needs", "710824005"],
+        ["Assessment for housing insecurity", "1148447008"],
+        # 225340009 is not a member of the housing value set above. It is left
+        # in place because referrals already exist that use it.
         ["Housing assessment", "225340009"],
         ["Referral to housing service", "710911006"],
       ],

--- a/app/javascript/controllers/taskform_controller.js
+++ b/app/javascript/controllers/taskform_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     "goal",
     "performer",
     "consent",
+    "supportingResources",
     "submitButton",
     "capacityBadge",
     "blockedAlert",
@@ -46,8 +47,35 @@ export default class extends Controller {
 
   handleSubmit(event) {
     event.preventDefault(); // Prevent the default form submission behavior
+    if (!this.validateSupportingResources()) return;
+
     const formElement = document.getElementById("task-form");
     formElement.submit(); // Manually submit the form
+  }
+
+  // Task.input is 0..*, so attaching nothing is valid. An option that is not
+  // "<ResourceType>/<id>" is not: value[x] is Reference(Resource) with no
+  // targetProfile, and a value missing its resource type cannot be turned into
+  // a reference on the server side either.
+  validateSupportingResources() {
+    if (!this.hasSupportingResourcesTarget) return true;
+
+    const target = this.supportingResourcesTarget;
+    const malformed = Array.from(target.selectedOptions)
+      .map(option => option.value)
+      .filter(value => value !== "")
+      .filter(value => !/^[A-Z][A-Za-z]+\/[A-Za-z0-9.-]{1,64}$/.test(value));
+
+    if (malformed.length === 0) {
+      target.setCustomValidity("");
+      return true;
+    }
+
+    target.setCustomValidity(
+      `Cannot attach ${malformed.join(", ")}: expected "ResourceType/id".`
+    );
+    target.reportValidity();
+    return false;
   }
 
   updateRequestOptions(selectedCategory) {
@@ -67,6 +95,10 @@ export default class extends Controller {
     });
   }
 
+  // The demo auto-fill deliberately leaves the additional-content picker alone.
+  // Attaching a patient's clinical record to a referral is the provider's
+  // decision, and a random selection would send whatever happened to be first
+  // in the list.
   populateFieldsRandomly() {
     // this.setRandomValue(this.statusTarget);
     this.statusTarget.selectedIndex = 1;

--- a/app/models/fhir_profiles.rb
+++ b/app/models/fhir_profiles.rb
@@ -53,6 +53,13 @@ module FhirProfiles
   RESULTING_ACTIVITY_CODE = "resulting-activity".freeze
   RESULTING_ACTIVITY_DISPLAY = "Resulting Activity".freeze
 
+  # SDOHCC-CodeSystemTemporaryCodes concept that SDOHCC-ObservationProgramEnrollmentStatus
+  # fixes category[enrollment] to. Task.output:AdditionalContent carries
+  # assessments, screening responses, goals, conditions and questionnaire
+  # responses as well as enrollment status, so the category is what identifies
+  # an enrollment status Observation among them.
+  PROGRAM_ENROLLMENT_CATEGORY_CODE = "program-enrollment".freeze
+
   # --- US Core extensions (hl7.fhir.us.core) ---
 
   # US Core Race Extension

--- a/app/models/fhir_profiles.rb
+++ b/app/models/fhir_profiles.rb
@@ -23,6 +23,14 @@ module FhirProfiles
   # SDOHCC Condition
   CONDITION = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-Condition".freeze
 
+  # SDOHCC Observation Assessment - a derived finding, e.g. "Inadequate oral
+  # food intake for physiological needs".
+  OBSERVATION_ASSESSMENT = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationAssessment".freeze
+  # SDOHCC Observation Screening Response - one answer to one screening
+  # question, e.g. "Within the past 12 months we worried whether our food would
+  # run out before we got money to buy more".
+  OBSERVATION_SCREENING_RESPONSE = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationScreeningResponse".freeze
+
   # SDOHCC Observation Race OMB
   OBSERVATION_RACE_OMB = "http://hl7.org/fhir/us/sdoh-clinicalcare/StructureDefinition/SDOHCC-ObservationRaceOMB".freeze
   # SDOHCC Observation Ethnicity OMB

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,7 +1,7 @@
 class Observation
   include ModelHelper
 
-  attr_reader :id, :code, :category, :value, :effective_date_time, :fhir_resource
+  attr_reader :id, :code, :category, :value, :effective_date_time, :note, :fhir_resource
 
   def initialize(fhir_observation)
     @id = fhir_observation.id
@@ -9,11 +9,36 @@ class Observation
     remove_client_instances(@fhir_resource)
     @code = get_code_string(fhir_observation.code)
     @category = get_category_display(fhir_observation.category)
+    @category_codes = get_category_codes(fhir_observation.category)
     @value = get_code_string(fhir_observation.valueCodeableConcept) if fhir_observation.valueCodeableConcept.present?
+    @value_coding = fhir_observation.valueCodeableConcept&.coding&.first
     @effective_date_time = fhir_observation.effectiveDateTime
+    @note = fhir_observation.note&.map { |note| note&.text }&.compact&.join(" ").presence
+  end
+
+  # An SDOHCC Observation Program Enrollment Status: the profile fixes
+  # category[enrollment] to program-enrollment, so that is what marks one out
+  # from any other Observation a Task.output entry may reference.
+  def program_enrollment?
+    @category_codes.include?(FhirProfiles::PROGRAM_ENROLLMENT_CATEGORY_CODE)
+  end
+
+  # Observation.value[x] as a code from SDOHCC-ValueSetEnrollmentStatus:
+  # enrolled, not-enrolled or not-enrolled-on-waitlist. The code, not the
+  # display, is what a badge colour is chosen from.
+  def enrollment_status_code
+    @value_coding&.code
+  end
+
+  def enrollment_status_display
+    @value_coding&.display.presence || @value_coding&.code&.tr("-", " ")&.titleize
   end
 
   private
+
+  def get_category_codes(category)
+    Array(category).flat_map { |c| Array(c&.coding) }.map { |coding| coding&.code }.compact
+  end
 
   def get_code_string(code)
     c = code&.coding&.first

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -21,10 +21,14 @@ class Procedure
     display || codeable_concept&.coding&.map(&:code)&.join(", ")&.gsub("-", " ")&.titleize
   end
 
+  # Procedure.reasonReference is 0..*, and a referral made with no problem
+  # recorded produces a Procedure with none. Reading .reference off nil raised,
+  # TaskIoEntry's rescue turned that into an unresolved output, and the Outcomes
+  # cell fell back to a bare "Resulting Activity" with nothing behind it.
   def read_reference(reference, fhir_client)
-    id = reference.reference_id
+    id = reference&.reference_id
 
-    return nil if fhir_client.nil?
+    return nil if id.blank? || fhir_client.nil?
 
     condition = fhir_client.read(FHIR::Condition, id).resource
     # sometimes for some reason read returns FHIR::Bundle

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -35,6 +35,21 @@ class Task
     inputs.select(&:additional_content?)
   end
 
+  # The Enrollment Status Observation this referral was closed with, if there
+  # is one.
+  #
+  # enrollment.html, referral-triggered workflow: "To close the loop on the
+  # referral, the CBO updates the Task, pointing to the Enrollment Status
+  # Observation in Task.output." It arrives in the AdditionalContent slice,
+  # which is shared with assessments, goals and conditions, so the Observation's
+  # own category is what identifies it.
+  def enrollment_status
+    additional_content_outputs
+      .map(&:resource)
+      .compact
+      .find { |resource| resource.is_a?(Observation) && resource.program_enrollment? }
+  end
+
   # The first resulting-activity output. Kept so callers written against the
   # single-outcome API keep working while they move to #outputs.
   def outcome

--- a/app/models/task_io_entry.rb
+++ b/app/models/task_io_entry.rb
@@ -82,7 +82,45 @@ class TaskIoEntry
     resource&.id || resource_id
   end
 
+  # What the referenced resource actually says, for a table cell that would
+  # otherwise read "Additional Content (QuestionnaireResponse)". A completed
+  # assessment comes back as several resources at once, and the reader needs to
+  # tell a food insecurity Condition from a PRAPARE response without opening
+  # each modal in turn.
+  def resource_label
+    fhir_resource = resource&.fhir_resource
+    return if fhir_resource.nil?
+
+    text =
+      case fhir_resource
+      when FHIR::Goal then codeable_display(fhir_resource.description)
+      when FHIR::CarePlan then fhir_resource.title.presence || codeable_display(fhir_resource.category&.first)
+      when FHIR::QuestionnaireResponse then questionnaire_display(fhir_resource)
+      else codeable_display(fhir_resource.code)
+      end
+
+    text.presence
+  end
+
   private
+
+  def codeable_display(codeable_concept)
+    return if codeable_concept.blank?
+
+    coding = Array(codeable_concept.coding).first
+    codeable_concept.text.presence || coding&.display.presence || coding&.code
+  end
+
+  # QuestionnaireResponse.questionnaire is a canonical URL. Resolving it would
+  # be one more read per outcome on a table that already reads every referenced
+  # resource, so the last segment is spaced out instead:
+  # ".../SDOHCC-QuestionnairePRAPARE" reads as "Questionnaire PRAPARE".
+  def questionnaire_display(fhir_resource)
+    segment = fhir_resource.questionnaire.to_s.split("|").first.to_s.split("/").reject(&:blank?).last
+    return if segment.blank?
+
+    segment.sub(/\ASDOHCC-/, "").gsub(/([a-z])([A-Z])/, '\1 \2')
+  end
 
   # The temporary-codes coding is the one the profile discriminates on; fall
   # back to the first coding so an off-spec entry still describes itself.

--- a/app/models/task_io_entry.rb
+++ b/app/models/task_io_entry.rb
@@ -96,7 +96,15 @@ class TaskIoEntry
       when FHIR::Goal then codeable_display(fhir_resource.description)
       when FHIR::CarePlan then fhir_resource.title.presence || codeable_display(fhir_resource.category&.first)
       when FHIR::QuestionnaireResponse then questionnaire_display(fhir_resource)
-      else codeable_display(fhir_resource.code)
+      when FHIR::Consent then codeable_display(Array(fhir_resource.category).first)
+      when FHIR::DocumentReference then fhir_resource.description.presence || codeable_display(fhir_resource.type)
+      else
+        # Task.input:AdditionalContent.value[x] is Reference(Resource) with no
+        # targetProfile, so anything can arrive here and not every resource type
+        # has a code element - FHIR::Consent has category, scope and provision
+        # and no code at all. Label what can be labelled; the rest falls back to
+        # the resource type in the caller.
+        codeable_display(fhir_resource.code) if fhir_resource.respond_to?(:code)
       end
 
     text.presence

--- a/app/views/action_steps/_form_modal.html.erb
+++ b/app/views/action_steps/_form_modal.html.erb
@@ -59,6 +59,22 @@
             <%= f.label :consent, "Consent", class: "form-label" %>
             <%= f.collection_select :consent, consents, :id, :code, { prompt: 'Select Consent' }, { class: "form-select", data: { taskform_target: "consent" } } %>
           </div>
+          <%# Task.input:AdditionalContent - "the provider may attach additional %>
+          <%# content relevant for the care of the individual through the SDOHCC %>
+          <%# Task resource" (referral_workflow.html). value[x] is %>
+          <%# Reference(Resource) with no targetProfile, so each option carries %>
+          <%# "<ResourceType>/<id>" and not a bare id. %>
+          <div class="mb-3">
+            <%= f.label :additional_content_ids, "Additional Content", class: "form-label" %>
+            <%= f.select :additional_content_ids,
+                  grouped_options_for_select(additional_content_options),
+                  {},
+                  { multiple: true, size: 8, class: "form-select", data: { taskform_target: "supportingResources" } } %>
+            <div class="form-text">
+              Optional. Ctrl-click (Cmd-click on a Mac) to attach more than one. Whatever you attach
+              is sent to the referral target as Task additional content.
+            </div>
+          </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/app/views/action_steps/_observation_modal.html.erb
+++ b/app/views/action_steps/_observation_modal.html.erb
@@ -1,0 +1,46 @@
+<%# Enrollment Status Observation behind the badge in the Outcomes column. %>
+<%# Separate from action_steps/_procedure_modal, whose card header is hardcoded %>
+<%# to Procedure/<id> and whose fields (performed date, addresses) do not apply. %>
+<div id="enrollment-observation-modal-<%= resource.id %>" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Enrollment Status</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="card">
+          <div class="card-header">
+            <h6 class="card-title">Observation/<%= resource.id %></h6>
+          </div>
+          <div class="card-body">
+            <div class="label-value">
+              <span class="fw-semibold">Program:</span>
+              <span class="small-text"><%= resource.code || "--" %></span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Category:</span>
+              <span class="small-text"><%= resource.category || "--" %></span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Enrollment Status:</span>
+              <span class="badge <%= enrollment_status_badge_class(resource.enrollment_status_code) %>">
+                <%= resource.enrollment_status_display || "--" %>
+              </span>
+            </div>
+            <div class="label-value">
+              <span class="fw-semibold">Enrollment Date:</span>
+              <span class="small-text"><%= resource.effective_date_time || "--" %></span>
+            </div>
+            <% if resource.note.present? %>
+              <div class="label-value">
+                <span class="fw-semibold">Note:</span>
+                <span class="small-text"><%= resource.note %></span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/action_steps/_procedure_modal.html.erb
+++ b/app/views/action_steps/_procedure_modal.html.erb
@@ -27,10 +27,14 @@
               <span class="fw-semibold">Performed Date:</span>
               <span class="small-text"><%= resource.performed_date.to_date %></span>
             </div>
-            <div class="label-value">
-              <span class="fw-semibold">Addresses:</span>
-              <span class="small-text">Condition/<%= resource.problem&.id %></span>
-            </div>
+            <%# reasonReference is 0..*, so a Procedure can have no problem to %>
+            <%# address; the row read "Condition/" with nothing after it. %>
+            <% if resource.problem.present? %>
+              <div class="label-value">
+                <span class="fw-semibold">Addresses:</span>
+                <span class="small-text">Condition/<%= resource.problem.id %></span>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -121,7 +121,11 @@
                         <%= render "action_steps/procedure_modal", resource: output.resource %>
                       <% end %>
                     <% else %>
-                      <%= link_to output.display_type, "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <%# Name the resource, not the slice it arrived in: a %>
+                      <%# completed assessment returns several at once and %>
+                      <%# "Additional Content (QuestionnaireResponse)" three %>
+                      <%# times over says nothing about what came back. %>
+                      <%= link_to "#{output.resource_label.presence || output.display_type} (#{output.display_type})", "#fhir-resource-modal-#{output.id}", data: { bs_toggle: "modal" } %>
                       <% content_for :modals do %>
                         <%= render "shared/fhir_resource_modal", resource: output.resource %>
                       <% end %>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -116,7 +116,7 @@
                         <%= render "shared/string_modal", { id: "#{referral.id}-#{index}", resource: output.value } %>
                       <% end %>
                     <% elsif output.resource_type == "Procedure" %>
-                      <%= link_to output.display_type, "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
+                      <%= link_to "#{output.resource_label.presence || output.display_type} (#{output.display_type})", "#referral-procedure-modal-#{output.id}", data: { bs_toggle: "modal" } %>
                       <% content_for :modals do %>
                         <%= render "action_steps/procedure_modal", resource: output.resource %>
                       <% end %>

--- a/app/views/action_steps/_table.html.erb
+++ b/app/views/action_steps/_table.html.erb
@@ -90,9 +90,24 @@
 
             <% if type == "completed" %>
               <td>
-                <% if referral&.outputs.present? %>
-                  <% referral.outputs.each_with_index do |output, index| %>
-                    <% if index.positive? %>, <% end %>
+                <%# The enrollment status the CBO closed the referral with leads %>
+                <%# the cell: it is the outcome the referrer is looking for, and %>
+                <%# it gets its own modal rather than the Procedure's. %>
+                <% enrollment = referral&.enrollment_status %>
+                <% if enrollment.present? %>
+                  <%= link_to "#enrollment-observation-modal-#{enrollment.id}", data: { bs_toggle: "modal" }, class: "text-decoration-none" do %>
+                    <span class="badge <%= enrollment_status_badge_class(enrollment.enrollment_status_code) %>">
+                      <%= enrollment.enrollment_status_display %>
+                    </span>
+                  <% end %>
+                  <% content_for :modals do %>
+                    <%= render "action_steps/observation_modal", resource: enrollment %>
+                  <% end %>
+                <% end %>
+                <% other_outputs = Array(referral&.outputs).reject { |output| enrollment.present? && output.resource == enrollment } %>
+                <% if other_outputs.present? %>
+                  <% other_outputs.each_with_index do |output, index| %>
+                    <% if index.positive? || enrollment.present? %>, <% end %>
                     <% if output.resource.blank? && output.value.blank? %>
                       <span class="small-text"><%= output.display_type %></span>
                     <% elsif output.resource.blank? %>
@@ -112,7 +127,7 @@
                       <% end %>
                     <% end %>
                   <% end %>
-                <% else %>
+                <% elsif enrollment.blank? %>
                   --
                 <% end %>
               </td>


### PR DESCRIPTION
### What this does

A provider can now attach existing patient resources to a referral. Each one becomes a
`Task.input:AdditionalContent` entry on the referral Task.

The guidance is on the profile page, under **Content-Rich Referral** in
`StructureDefinition-SDOHCC-TaskForReferralManagement`: "If a referral requester wants to include
additional information relevant that could be relevant for an individual's provision of care or
assessment by the referral recipient, the requester can attach these resources to the initial Task
resource through `Task.input`. This profile slices the `Task.input` element to allow the referral
requester to reference any resource to allow for flexibility in the information that is sent to the
referral recipient." Its worked example is a food-insecurity referral carrying "the completed
assessment(s) that led to the action of submitting a referral … (`QuestionnaireResponse`, `SDOHCC
Observation Screening Response`, etc.)".

`referral_workflow.html` mentions the capability once more, in row 6 of the general workflow table.
Neither page names the `AdditionalContent` slice or the `additional-content` code; that binding comes
from the StructureDefinition, which fixes `Task.input:AdditionalContent.type` to `additional-content`
in `SDOHCC-CodeSystemTemporaryCodes` and leaves `value[x]` as `Reference(Resource)` **with no
`targetProfile`**.

Because the reference is unconstrained, a bare id cannot be turned into one. The picker submits
`"<ResourceType>/<id>"` and both halves are used. The resource type is checked against an allow-list
(`Condition`, `Consent`, `DocumentReference`, `Goal`, `Observation`, `QuestionnaireResponse`,
`ServiceRequest`) and the id against the FHIR id pattern before either goes near a reference string,
so no unvalidated parameter is interpolated into a reference. Parsing reuses
`TaskIoEntry.parse_reference`, which is what reads these references back.

### Changes

- `app/controllers/tasks_controller.rb` — frozen `ADDITIONAL_CONTENT_TYPE` CodeableConcept and
  `ADDITIONAL_CONTENT_RESOURCE_TYPES` allow-list; private `task_input` builder wired into
  `FHIR::Task.new`. `task_input` returns `nil`, not `[]`, when nothing is selected, so the element is
  omitted rather than emitted empty.
- `app/helpers/tasks_helper.rb` — `additional_content_options`, grouped by resource type for
  `grouped_options_for_select`. Groups come from what the dashboard has already loaded
  (`@active_problems` + `@active_health_concerns`, `@active_goals`, `@social_risk_assessments`,
  `@personal_characteristics`, `@service_requests`, `consents`), so no group costs an extra server
  read. The resource type on each option comes off the FHIR resource itself, not off the group label.
- `app/views/action_steps/_form_modal.html.erb` — an "Additional Content" multi-select after the
  Consent group and before `.modal-footer`.
- `app/javascript/controllers/taskform_controller.js` — `supportingResources` target and submit
  validation (nothing selected is valid; a malformed value is not). The demo auto-fill deliberately
  leaves the picker alone: what of a patient's record travels with a referral is the provider's
  decision, not a random one.
- `app/models/task_io_entry.rb` — see "Bug found on the way" below.

`ServiceRequest.reasonReference` / `supportingInfo` already omit themselves when the param is blank —
that was fixed on the parent branch in `3ca57bc`, and the regression test below confirms it still
holds.

### Bug found on the way

`Task.output:AdditionalContent` is constrained to a list of profiles that all have a `code` element.
`Task.input:AdditionalContent` is not, and `TaskIoEntry#resource_label` fell through to
`fhir_resource.code` for anything it did not recognise. `FHIR::Consent` has `category`, `scope` and
`provision` and no `code` at all, so labelling an attached Consent raised `NoMethodError` and took the
whole receiving dashboard down with a 500. Labelling now handles Consent and DocumentReference
explicitly and reaches for `code` only where the resource has one. Committed separately
(`Handle resource types with no code element in Task I/O labels`) and applied identically in all three
clients so the shared model does not diverge.

### Verification

Local stack, `feature/content-rich-referral` built on ports 3030 / 3031 / 3032, against the SDOH EHR
server. Patient `pat-53234`.

- Referral with a Condition, an Observation, a QuestionnaireResponse and a Consent attached →
  `Task/79ebb7df-51b5-45a0-9521-0714603d0c7d` carries **four** `input` entries, every one
  `type.coding.code = additional-content` in `SDOHCC-CodeSystemTemporaryCodes`, every
  `valueReference.reference` carrying resource type and id and resolvable on the server.
- Referral with nothing attached → `Task/6b8efc9a-3d05-4254-be1e-d4fc8eea89c0` has **no `input`
  element at all**, and its ServiceRequest has neither `reasonReference` nor `supportingInfo` — no
  bare `"Condition/"` or `"Consent/"`.
- Capacity gating still fires on performer selection.

### Validation

`validator_cli.jar` 6.10.2 (Java 17), resources pulled back from the FHIR server, profile asserted
with `-profile` rather than trusted from `meta.profile`, against the CI package
`https://build.fhir.org/ig/HL7/fhir-sdoh-clinicalcare/package.tgz` (resolves, 732 KB).

| Resource | Errors | Warnings |
|---|---|---|
| `Task/79ebb7df…` (4 attachments) | **0** | 2 |
| `Task/6b8efc9a…` (no attachments) | **0** | 2 |
| `ServiceRequest/e95190d7…` | **0** | 2 |

Warnings are `dom-6` (no narrative), a trailing space in `Task.requester.display` that comes from the
Practitioner record on the server, and the unresolvable VSAC-backed
`us-core-procedure-code|7.0.0` expansion. None originate in this change.

### Which Observations the picker offers, and why

The IG's example for `Task.input` names `QuestionnaireResponse` and `SDOHCC Observation Screening
Response`, and `output[AdditionalContent].valueReference` is constrained to a list that includes both
`SDOHCCObservationAssessment` and `SDOHCCObservationScreeningResponse`. So the picker offers both, in
two groups: **Assessment Findings** (the derived findings — "Inadequate oral food intake for
physiological needs") above **Screening Responses** (the individual question answers behind them).
Splitting them keeps the three findings scannable above the fifteen answers.

They are searched by `_profile`, not by `category`. An `SDOHCC-ObservationAssessment` carries
category `sdoh` on some domains and `social-history` on others, so `category=sdoh` returns 14 of the
18 Observations on the test patient and silently drops the rest.

`DocumentReference` stays in the controller's allow-list — a reference to one is legal and would be
rendered — but nothing loads DocumentReferences for a patient yet, so no group appears for them.